### PR TITLE
Fix issue with DefaultApiClientFactory

### DIFF
--- a/src/client/ApiClientFactory.ts
+++ b/src/client/ApiClientFactory.ts
@@ -8,8 +8,8 @@ export class DefaultApiClientFactory {
     constructor(private apiUrl: string = process.env.API_URL || "", private apiKey: string = process.env.CHS_API_KEY || "") {
     }
 
-    newApiClient(apiUrl: string, apiKey: string): ApiClient {
-        return createApiClient(apiKey, undefined, apiUrl);
+    newApiClient(): ApiClient {
+        return createApiClient(this.apiKey, undefined, this.apiUrl);
     }
 }
 

--- a/test/client/DefaultApiClientFactory.test.ts
+++ b/test/client/DefaultApiClientFactory.test.ts
@@ -1,0 +1,46 @@
+import {DefaultApiClientFactory} from "../../src/client/ApiClientFactory";
+
+describe("DefaultApiClientFactory", () => {
+    it("Constructs a new ApiClient instance using apiUrl and apiKey field values", () => {
+        // given
+        const expectedBaseUrl = "http://0.0.0.0";
+        const expectedApiKey = "F00DFACE";
+        const factory = new DefaultApiClientFactory(expectedBaseUrl, expectedApiKey);
+
+        // when
+        const actual = factory.newApiClient();
+        const apiClient: any = actual.apiClient;
+
+        // then
+        expect(apiClient.options.baseUrl).toEqual(expectedBaseUrl);
+        expect(apiClient.options.apiKey).toEqual(expectedApiKey);
+    });
+
+    it("Constructs a new ApiClient instance using environment variables as default values", () => {
+        // given
+        process.env.API_URL = "http://localhost";
+        process.env.CHS_API_KEY = "API_KEY";
+        const factory = new DefaultApiClientFactory();
+
+        // when
+        const actual = factory.newApiClient();
+        const apiClient: any = actual.apiClient;
+
+        // then
+        expect(apiClient.options.baseUrl).toEqual("http://localhost");
+        expect(apiClient.options.apiKey).toEqual("API_KEY");
+    });
+
+    it("Throws an error if apiUrl or apiKey are falsy", () => {
+        // given
+        process.env.API_URL = "";
+        process.env.CHS_API_KEY = "";
+        const factory = new DefaultApiClientFactory();
+
+        // when
+        const execution = () => factory.newApiClient();
+
+        // then
+        expect(execution).toThrowError();
+    });
+});


### PR DESCRIPTION
* Fix an issue whereby DefaultApiClientFactory throws an error when
  creating a new ApiClient instance without any arguments.