### PR TITLE
Update cucumber tests in orders admin site

### DIFF
--- a/features/order_details_page.feature
+++ b/features/order_details_page.feature
@@ -7,8 +7,8 @@ Feature: View order details
       | Ordered by     | Company name         | Company number | Certificate type                            | Registered office address            | The names of all current company directors                                      | The names of all current secretaries                                | Company objects | Liquidators' details |
       | demo@ch.gov.uk | TEST COMPANY LIMITED | 00000000       | Incorporation with all company name changes | Current address and the two previous | Including directors':\n\nCorrespondence address\nDate of birth (month and year) | Including secretaries':\n\nCorrespondence address\nAppointment date | Yes             | Yes                  |
     And The following delivery details should be displayed:
-      | Delivery method                                            | Delivery details                                                                         |
-      | Standard delivery (aim to dispatch within 10 working days) | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
+      | Delivery method                                           | Email copy required                              | Delivery details                                                                         |
+      | Standard delivery (aim to dispatch within 10 working days)| Email only available for express delivery method | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
     And The following payment details should be displayed:
       | Payment reference | Fee |
       | CAFE              | £15 |
@@ -20,8 +20,8 @@ Feature: View order details
       | Ordered by     | Company name         | Company number | Certificate type                            | Statement of good standing | Registered office address          | The names of all current company directors | The names of all current secretaries | Company objects |
       | demo@ch.gov.uk | TEST COMPANY LIMITED | 00000000       | Incorporation with all company name changes | Yes                        | All current and previous addresses | Yes                                        | Yes                                  | Yes             |
     And The following delivery details should be displayed:
-      | Delivery method                                            | Delivery details                                                                         |
-      | Standard delivery (aim to dispatch within 10 working days) | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
+      | Delivery method                                            | Email copy required                              | Delivery details                                                                         |
+      | Standard delivery (aim to dispatch within 10 working days) | Email only available for express delivery method | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
     And The following payment details should be displayed:
       | Payment reference | Fee |
       | CAFE              | £15 |
@@ -33,8 +33,8 @@ Feature: View order details
       | Ordered by     | Company name         | Company number | Certificate type                            | Registered office address | The names of all current company directors | The names of all current secretaries | Company objects | Administrators' details |
       | demo@ch.gov.uk | TEST COMPANY LIMITED | 00000000       | Incorporation with all company name changes | No                        | No                                         | No                                   | No              | No                      |
     And The following delivery details should be displayed:
-      | Delivery method                                            | Delivery details                                                                         |
-      | Standard delivery (aim to dispatch within 10 working days) | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
+      | Delivery method                                            | Email copy required                              | Delivery details                                                                         |
+      | Standard delivery (aim to dispatch within 10 working days) | Email only available for express delivery method | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
     And The following payment details should be displayed:
       | Payment reference | Fee |
       | CAFE              | £15 |
@@ -46,8 +46,8 @@ Feature: View order details
       | Ordered by     | Company name         | Company number | Certificate type                            | Registered office address            | The names of all current designated members                                              | The names of all current members                                | Administrators' details |
       | demo@ch.gov.uk | TEST COMPANY LIMITED | 00000000       | Incorporation with all company name changes | Current address and the two previous | Including designated members':\n\nCorrespondence address\nDate of birth (month and year) | Including members':\n\nCorrespondence address\nAppointment date | Yes                     |
     And The following delivery details should be displayed:
-      | Delivery method                                            | Delivery details                                                                         |
-      | Standard delivery (aim to dispatch within 10 working days) | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
+      | Delivery method                                            | Email copy required                              | Delivery details                                                                         |
+      | Standard delivery (aim to dispatch within 10 working days) | Email only available for express delivery method | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
     And The following payment details should be displayed:
       | Payment reference | Fee |
       | CAFE              | £15 |
@@ -59,8 +59,8 @@ Feature: View order details
       | Ordered by     | Company name         | Company number | Certificate type                            | Statement of good standing | Registered office address | The names of all current designated members | The names of all current members |
       | demo@ch.gov.uk | TEST COMPANY LIMITED | 00000000       | Incorporation with all company name changes | No                         | No                        | Yes                                         | No                               |
     And The following delivery details should be displayed:
-      | Delivery method                                            | Delivery details                                                                         |
-      | Standard delivery (aim to dispatch within 10 working days) | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
+      | Delivery method                                            | Email copy required                              | Delivery details                                                                         |
+      | Standard delivery (aim to dispatch within 10 working days) | Email only available for express delivery method | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
     And The following payment details should be displayed:
       | Payment reference | Fee |
       | CAFE              | £15 |
@@ -72,8 +72,8 @@ Feature: View order details
       | Ordered by     | Company name         | Company number | Certificate type                            | Statement of good standing | Principal place of business          | The names of all current general partners | The names of all current limited partners | General nature of business |
       | demo@ch.gov.uk | TEST COMPANY LIMITED | 00000000       | Incorporation with all company name changes | Yes                        | Current address and the two previous | Yes                                       | Yes                                       | Yes                        |
     And The following delivery details should be displayed:
-      | Delivery method                                            | Delivery details                                                                         |
-      | Standard delivery (aim to dispatch within 10 working days) | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
+      | Delivery method                                            | Email copy required                              | Delivery details                                                                         |
+      | Standard delivery (aim to dispatch within 10 working days) | Email only available for express delivery method | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
     And The following payment details should be displayed:
       | Payment reference | Fee |
       | CAFE              | £15 |

--- a/features/order_details_page.feature
+++ b/features/order_details_page.feature
@@ -46,8 +46,8 @@ Feature: View order details
       | Ordered by     | Company name         | Company number | Certificate type                            | Registered office address            | The names of all current designated members                                              | The names of all current members                                | Administrators' details |
       | demo@ch.gov.uk | TEST COMPANY LIMITED | 00000000       | Incorporation with all company name changes | Current address and the two previous | Including designated members':\n\nCorrespondence address\nDate of birth (month and year) | Including members':\n\nCorrespondence address\nAppointment date | Yes                     |
     And The following delivery details should be displayed:
-      | Delivery method                                            | Email copy required                              | Delivery details                                                                         |
-      | Standard delivery (aim to dispatch within 10 working days) | Email only available for express delivery method | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
+      | Delivery method                                            | Delivery details                                                                         |
+      | Standard delivery (aim to dispatch within 10 working days) | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
     And The following payment details should be displayed:
       | Payment reference | Fee |
       | CAFE              | £15 |
@@ -59,8 +59,8 @@ Feature: View order details
       | Ordered by     | Company name         | Company number | Certificate type                            | Statement of good standing | Registered office address | The names of all current designated members | The names of all current members |
       | demo@ch.gov.uk | TEST COMPANY LIMITED | 00000000       | Incorporation with all company name changes | No                         | No                        | Yes                                         | No                               |
     And The following delivery details should be displayed:
-      | Delivery method                                            | Email copy required                              | Delivery details                                                                         |
-      | Standard delivery (aim to dispatch within 10 working days) | Email only available for express delivery method | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
+      | Delivery method                                            | Delivery details                                                                         |
+      | Standard delivery (aim to dispatch within 10 working days) | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
     And The following payment details should be displayed:
       | Payment reference | Fee |
       | CAFE              | £15 |
@@ -72,8 +72,8 @@ Feature: View order details
       | Ordered by     | Company name         | Company number | Certificate type                            | Statement of good standing | Principal place of business          | The names of all current general partners | The names of all current limited partners | General nature of business |
       | demo@ch.gov.uk | TEST COMPANY LIMITED | 00000000       | Incorporation with all company name changes | Yes                        | Current address and the two previous | Yes                                       | Yes                                       | Yes                        |
     And The following delivery details should be displayed:
-      | Delivery method                                            | Email copy required                              | Delivery details                                                                         |
-      | Standard delivery (aim to dispatch within 10 working days) | Email only available for express delivery method | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
+      | Delivery method                                            | Delivery details                                                                         |
+      | Standard delivery (aim to dispatch within 10 working days) | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
     And The following payment details should be displayed:
       | Payment reference | Fee |
       | CAFE              | £15 |

--- a/src/views/orderDetails/delivery_details_component.njk
+++ b/src/views/orderDetails/delivery_details_component.njk
@@ -11,14 +11,16 @@
         </dd>
     </div>
 
-    <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-             Email copy required
-        </dt>
-        <dd class="govuk-summary-list__value">
-            {{ control.data.emailCopyRequired }}
-        </dd>
-    </div>
+    {% if control.data.emailCopyRequired %} 
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+                Email copy required
+            </dt>
+            <dd class="govuk-summary-list__value">
+                {{ control.data.emailCopyRequired }}
+            </dd>
+        </div>
+    {% endif %}
 
     <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">


### PR DESCRIPTION
Fix cucumber tests and add check for if `emailCopyRequired` is present as it is not implemented in all company types at present.