### PR TITLE
GCI-2137 Order search endpoint reworked as checkout search endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -448,9 +448,9 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
     "@companieshouse/api-sdk-node": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.7.tgz",
-      "integrity": "sha512-WjqrDjC3MuBVl5omI3n3i26iZZobMgDEMlmWFQegBR/SwhxpISw6Fj/VUfnVbEQ5uGQjpSr54yH9bF8rdrcHbg==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.9.tgz",
+      "integrity": "sha512-9M2uis4SL9h5NMw14X3W8nxjz1E7uo4iL+kxsEzegId62B/8adTsycDXCJTikjvJmFsYPm0ptmj0WsMpyWYWsA==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sonarqube": "sonar-scanner"
   },
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.7",
+    "@companieshouse/api-sdk-node": "^2.0.9",
     "@companieshouse/node-session-handler": "~4.1.6",
     "@companieshouse/structured-logging-node": "^1.0.4",
     "@types/nunjucks": "^3.2.1",

--- a/src/client/StubApiClientFactory.ts
+++ b/src/client/StubApiClientFactory.ts
@@ -160,7 +160,7 @@ export class StubApiClientFactory implements ApiClientFactory {
                     return self.checkoutResponse || self.defaultCheckoutResponse;
                 }
             },
-            orderSearchService: {
+            checkoutSearchService: {
                 async search(request: SearchRequest): Promise<ApiResult<ApiResponse<SearchResponse>>> {
                     return self.searchResponse || self.defaultSearchResponse;
                 }

--- a/src/search/OrderSearchService.ts
+++ b/src/search/OrderSearchService.ts
@@ -15,7 +15,7 @@ export class OrderSearchService implements SearchService {
 
     async findOrders(searchParameters: OrderSearchParameters): Promise<SearchResults> {
         const apiClient = this.apiClientFactory.newApiClient(searchParameters.token);
-        const response = await apiClient.orderSearchService.search(searchParameters.searchCriteria);
+        const response = await apiClient.checkoutSearchService.search(searchParameters.searchCriteria);
         return this.resultsMapper.map(response);
     }
 }

--- a/src/search/SearchResultsMapper.ts
+++ b/src/search/SearchResultsMapper.ts
@@ -4,7 +4,7 @@ import {ApiResponse, ApiResult} from "@companieshouse/api-sdk-node/dist/services
 import {Service} from "typedi";
 import "reflect-metadata";
 import {Status} from "../core/Status";
-import {OrderSummary as OrderSummaryResource} from "@companieshouse/api-sdk-node/dist/services/order/search/types";
+import {CheckoutSummary as OrderSummaryResource} from "@companieshouse/api-sdk-node/dist/services/order/search/types";
 import {createLogger} from "@companieshouse/structured-logging-node";
 import dayjs from "dayjs";
 

--- a/src/search/SearchResultsMapper.ts
+++ b/src/search/SearchResultsMapper.ts
@@ -4,7 +4,7 @@ import {ApiResponse, ApiResult} from "@companieshouse/api-sdk-node/dist/services
 import {Service} from "typedi";
 import "reflect-metadata";
 import {Status} from "../core/Status";
-import {CheckoutSummary as OrderSummaryResource} from "@companieshouse/api-sdk-node/dist/services/order/search/types";
+import {CheckoutSummary as CheckoutSummaryResource} from "@companieshouse/api-sdk-node/dist/services/order/search/types";
 import {createLogger} from "@companieshouse/structured-logging-node";
 import dayjs from "dayjs";
 
@@ -55,7 +55,7 @@ export class SearchResultsMapper {
         }
     }
 
-    private mapLink(summary: OrderSummaryResource): string {
+    private mapLink(summary: CheckoutSummaryResource): string {
         if (summary.productLine === "item#certificate" && summary.paymentStatus === "paid") {
             return `/orders-admin/orders/${summary.id}`;
         } else {
@@ -63,7 +63,7 @@ export class SearchResultsMapper {
         }
     }
 
-    private mapOrderDate(summary: OrderSummaryResource): string {
+    private mapOrderDate(summary: CheckoutSummaryResource): string {
         if (!summary.orderDate) {
             return "Unknown";
         }
@@ -71,11 +71,11 @@ export class SearchResultsMapper {
         return dayjs(date).format("DD/MM/YYYY");
     }
 
-    private mapProductLine(summary: OrderSummaryResource): string {
+    private mapProductLine(summary: CheckoutSummaryResource): string {
         return productLineMappings[summary.productLine] || "Unknown";
     }
 
-    private mapPaymentStatus(summary: OrderSummaryResource): string {
+    private mapPaymentStatus(summary: CheckoutSummaryResource): string {
         return paymentStatusMappings[summary.paymentStatus] || "Unknown";
     }
 }

--- a/test/client/StubApiClientFactory.test.ts
+++ b/test/client/StubApiClientFactory.test.ts
@@ -16,7 +16,7 @@ describe("StubApiClientFactory", () => {
         const client = factory.newApiClient("F00DFACE");
 
         // when
-        const result = await client.orderSearchService.search({pageSize: 1000}) as Success<ApiResponse<SearchResponse>, ApiErrorResponse>;
+        const result = await client.checkoutSearchService.search({pageSize: 1000}) as Success<ApiResponse<SearchResponse>, ApiErrorResponse>;
 
         // then
         expect(result.isFailure()).toEqual(false);
@@ -36,7 +36,7 @@ describe("StubApiClientFactory", () => {
         const client = factory.newApiClient("F00DFACE");
 
         // when
-        const result = await client.orderSearchService.search({pageSize: 1000}) as Failure<ApiResponse<SearchResponse>, ApiErrorResponse>;
+        const result = await client.checkoutSearchService.search({pageSize: 1000}) as Failure<ApiResponse<SearchResponse>, ApiErrorResponse>;
 
         // then
         expect(result.isFailure()).toEqual(true);
@@ -51,7 +51,7 @@ describe("StubApiClientFactory", () => {
         const client = factory.newApiClient("F00DFACE");
 
         // when
-        const result = await client.orderSearchService.search({pageSize: 1000}) as Success<ApiResponse<SearchResponse>, ApiErrorResponse>;
+        const result = await client.checkoutSearchService.search({pageSize: 1000}) as Success<ApiResponse<SearchResponse>, ApiErrorResponse>;
 
         // then
         expect(result.isFailure()).toEqual(false);

--- a/test/orderdetails/OrderDetailsMapperFactory.test.ts
+++ b/test/orderdetails/OrderDetailsMapperFactory.test.ts
@@ -1,4 +1,4 @@
-import {OrderDetailsMapperFactory} from "../../dist/orderdetails/OrderDetailsMapperFactory";
+import {OrderDetailsMapperFactory} from "../../src/orderdetails/OrderDetailsMapperFactory";
 import {ApiErrorResponse, ApiResponse, ApiResult} from "@companieshouse/api-sdk-node/dist/services/resource";
 import {Checkout} from "@companieshouse/api-sdk-node/dist/services/order/checkout/types";
 import {Failure, Success} from "@companieshouse/api-sdk-node/dist/services/result";

--- a/test/search/OrderSearchService.test.ts
+++ b/test/search/OrderSearchService.test.ts
@@ -39,7 +39,7 @@ describe("OrderSearchService", () => {
         const apiClientFactory: any = {};
         apiClientFactory.newApiClient = jest.fn(() => {
             return {
-                orderSearchService: searchClient
+                checkoutSearchService: searchClient
             };
         });
         const mappedResults: SearchResults = {

--- a/test/search/OrderSearchService.test.ts
+++ b/test/search/OrderSearchService.test.ts
@@ -1,5 +1,5 @@
 import {jest} from "@jest/globals";
-import {SearchRequest, SearchResponse, CheckoutSummary as OrderSummaryResource} from "@companieshouse/api-sdk-node/dist/services/order/search";
+import {SearchRequest, SearchResponse, CheckoutSummary as CheckoutSummaryResource} from "@companieshouse/api-sdk-node/dist/services/order/search";
 import {OrderSearchService} from "../../src/search/OrderSearchService";
 import {SearchResults} from "../../src/search/SearchResults";
 import {Status} from "../../src/core/Status";
@@ -29,7 +29,7 @@ describe("OrderSearchService", () => {
                             link: "/link/to/order"
                         }
                     }
-                }] as OrderSummaryResource[]
+                }] as CheckoutSummaryResource[]
             } as SearchResponse
         });
         const searchClient: any = {};

--- a/test/search/OrderSearchService.test.ts
+++ b/test/search/OrderSearchService.test.ts
@@ -1,5 +1,5 @@
 import {jest} from "@jest/globals";
-import {SearchRequest, SearchResponse, OrderSummary as OrderSummaryResource} from "@companieshouse/api-sdk-node/dist/services/order/search";
+import {SearchRequest, SearchResponse, CheckoutSummary as OrderSummaryResource} from "@companieshouse/api-sdk-node/dist/services/order/search";
 import {OrderSearchService} from "../../src/search/OrderSearchService";
 import {SearchResults} from "../../src/search/SearchResults";
 import {Status} from "../../src/core/Status";

--- a/test/search/SearchResultsMapper.test.ts
+++ b/test/search/SearchResultsMapper.test.ts
@@ -1,6 +1,6 @@
 import {Failure, Success} from "@companieshouse/api-sdk-node/dist/services/result";
 import {ApiErrorResponse, ApiResponse} from "@companieshouse/api-sdk-node/dist/services/resource";
-import {OrderSummary as OrderSummaryResource, SearchResponse} from "@companieshouse/api-sdk-node/dist/services/order/search";
+import {CheckoutSummary as CheckoutSummaryResource, SearchResponse} from "@companieshouse/api-sdk-node/dist/services/order/search";
 import {SearchResultsMapper} from "../../src/search/SearchResultsMapper";
 import {OrderSummary} from "../../src/search/OrderSummary";
 import {SearchResults} from "../../src/search/SearchResults";
@@ -60,7 +60,7 @@ describe("SearchResultsMapper", () => {
                     id: "ORD-230230-230230",
                     email: "demo5@ch.gov.uk",
                     companyNumber: "23023023"
-                }] as OrderSummaryResource[]
+                }] as CheckoutSummaryResource[]
             } as SearchResponse
         });
         const mapper = new SearchResultsMapper();


### PR DESCRIPTION
* Update api-sdk-node to 2.0.9; order search endpoint has been reworked as checkout search endpoint - unpaid orders and orders with failed payments now included in search results.

Resolves:
[GCI-2137](https://companieshouse.atlassian.net/browse/GCI-2137)