### PR TITLE
GCI-2309 Add mapping logic for missing image delivery item summary page 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "api-enumerations"]
+	path = api-enumerations
+	url = https://github.com/companieshouse/api-enumerations

--- a/features/order_details_page.feature
+++ b/features/order_details_page.feature
@@ -50,7 +50,7 @@ Feature: View order details
       | Standard delivery (aim to dispatch within 10 working days) | Email only available for express delivery method | forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry |
     And The following payment details should be displayed:
       | Payment reference | Fee |
-      | CAFE              | £15 |
+        | CAFE              | £15 |
 
   Scenario: View order details for an existing active LLP certificate order
     Given The checkout endpoint will return a paid certificate order for an active LLP
@@ -105,7 +105,7 @@ Feature: View order details
     Then I should be taken to the signout handler
 
   Scenario: Back link
-    Given I am viewing a paid certificate order details     
+    Given I am viewing a paid certificate order details
       | Order number      | Email           | Company number | Order type     | Order date | Payment status | Linkable |
       | ORD-123123-123123 | demo1@ch.gov.uk | 12345678       | Certificate    | 11/04/2022 | Paid           | true     |
       | ORD-121212-121212 | demo2@ch.gov.uk | 12121212       | Certificate    | 11/04/2022 | In progress    | false    |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9656,7 +9656,7 @@
     "to-no-case": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
-      "integrity": "sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg=="
+      "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -9689,7 +9689,7 @@
     "to-snake-case": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-snake-case/-/to-snake-case-1.0.0.tgz",
-      "integrity": "sha512-joRpzBAk1Bhi2eGEYBjukEWHOe/IvclOkiJl3DtA91jV6NwQ3MwXA4FHYeqk8BNp/D8bmi9tcNbRu/SozP0jbQ==",
+      "integrity": "sha1-znRpE4l5RgGah+Yu366upMYIq4w=",
       "requires": {
         "to-space-case": "^1.0.0"
       }
@@ -9697,7 +9697,7 @@
     "to-space-case": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
-      "integrity": "sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==",
+      "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
       "requires": {
         "to-no-case": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9656,7 +9656,7 @@
     "to-no-case": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
-      "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo="
+      "integrity": "sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg=="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -9689,7 +9689,7 @@
     "to-snake-case": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-snake-case/-/to-snake-case-1.0.0.tgz",
-      "integrity": "sha1-znRpE4l5RgGah+Yu366upMYIq4w=",
+      "integrity": "sha512-joRpzBAk1Bhi2eGEYBjukEWHOe/IvclOkiJl3DtA91jV6NwQ3MwXA4FHYeqk8BNp/D8bmi9tcNbRu/SozP0jbQ==",
       "requires": {
         "to-space-case": "^1.0.0"
       }
@@ -9697,7 +9697,7 @@
     "to-space-case": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
-      "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
+      "integrity": "sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==",
       "requires": {
         "to-no-case": "^1.0.0"
       }
@@ -10557,6 +10557,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "yaml": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw=="
     },
     "yargs": {
       "version": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "morgan": "~1.9.1",
     "nunjucks": "^3.2.3",
     "reflect-metadata": "^0.1.13",
-    "typedi": "^0.10.0"
+    "typedi": "^0.10.0",
+    "yaml": "^2.1.1"
   },
   "devDependencies": {
     "@cucumber/cucumber": "^7.3.2",

--- a/src/govuk/GovUkSummaryList.ts
+++ b/src/govuk/GovUkSummaryList.ts
@@ -1,0 +1,14 @@
+export class GovUkSummaryList {
+    entries: GovUkSummaryListEntry[] = [];
+}
+
+export class GovUkSummaryListEntry {
+    key: GovUkSummaryListObject;
+    value: GovUkSummaryListObject;
+}
+
+export class GovUkSummaryListObject {
+    classes: string;
+    text?: string;
+    html?: string;
+}

--- a/src/govuk/GovUkSummaryList.ts
+++ b/src/govuk/GovUkSummaryList.ts
@@ -3,12 +3,12 @@ export class GovUkSummaryList {
 }
 
 export class GovUkSummaryListEntry {
-    key: GovUkSummaryListObject;
-    value: GovUkSummaryListObject;
+    key?: GovUkSummaryListObject;
+    value?: GovUkSummaryListObject;
 }
 
 export class GovUkSummaryListObject {
-    classes: string;
+    classes?: string;
     text?: string;
     html?: string;
 }

--- a/src/mappers/MapperRequest.ts
+++ b/src/mappers/MapperRequest.ts
@@ -1,0 +1,6 @@
+import { Item } from "@companieshouse/api-sdk-node/dist/services/order/order/types";
+
+export class MapperRequest {
+    constructor (public orderId: string, public item: Item) {
+    }
+}

--- a/src/orderitemsummary/FilingHistoryMapper.ts
+++ b/src/orderitemsummary/FilingHistoryMapper.ts
@@ -1,0 +1,55 @@
+import fs from "fs";
+import yaml from "yaml";
+
+const FILING_HISTORY_DESCRIPTIONS_PATH: string = "api-enumerations/filing_history_descriptions.yml";
+const DESCRIPTIONS_CONSTANT: string = "description";
+const filingHistoryDescriptions = yaml.parse(fs.readFileSync(FILING_HISTORY_DESCRIPTIONS_PATH, "utf8"));
+
+export const mapFilingHistoryDate = (dateString: string): string => {
+    const d = new Date(dateString);
+    const year = new Intl.DateTimeFormat("en", { year: "numeric" }).format(d);
+    const month = new Intl.DateTimeFormat("en", { month: "short" }).format(d);
+    const day = new Intl.DateTimeFormat("en", { day: "2-digit" }).format(d);
+
+    return `${day} ${month} ${year}`;
+};
+
+export const mapFilingHistory = (description: string, descriptionValues: Record<string, string>): string => {
+    const descriptionFromFile = getFullFilingHistoryDescription(description);
+    const mappedFilingHistoryDescription = mapFilingHistoryDescriptionValues(descriptionFromFile, descriptionValues || {});
+    return removeAsterisks(mappedFilingHistoryDescription);
+};
+
+const getFullFilingHistoryDescription = (descriptionKey: string): string => {
+    if (filingHistoryDescriptions === undefined) {
+        return descriptionKey;
+    } else {
+        return filingHistoryDescriptions[DESCRIPTIONS_CONSTANT][descriptionKey] || descriptionKey;
+    }
+};
+
+const mapFilingHistoryDescriptionValues = (description: string, descriptionValues: Record<string, string>) => {
+    if (descriptionValues.description) {
+        return descriptionValues.description;
+    } else {
+        return Object.entries(descriptionValues).reduce((newObj, [key, val]) => {
+            const value = key.includes("date") ? mapDateFullMonth(val) : val;
+            return newObj.replace("{" + key + "}", value as string);
+        }, description);
+    }
+};
+
+const mapDateFullMonth = (dateString: string): string => {
+    const d = new Date(dateString);
+    const year = new Intl.DateTimeFormat("en", { year: "numeric" }).format(d);
+    const month = new Intl.DateTimeFormat("en", { month: "long" }).format(d);
+    const day = new Intl.DateTimeFormat("en", { day: "2-digit" }).format(d);
+
+    return `${day} ${month} ${year}`;
+};
+
+const removeAsterisks = (description: string) => {
+    return description.replace(/\*/g, "");
+};
+
+

--- a/src/orderitemsummary/GovUkOrderItemSummaryView.ts
+++ b/src/orderitemsummary/GovUkOrderItemSummaryView.ts
@@ -1,8 +1,8 @@
 import { GovUkSummaryList } from "../govuk/GovUkSummaryList";
 
 export class GovUkOrderItemSummaryView {
-    orderId: string;
-    itemId: string;
+    orderId?: string;
+    itemId?: string;
     itemDetails: GovUkSummaryList = new GovUkSummaryList();
-    backLinkUrl: string;
+    backLinkUrl?: string;
 }

--- a/src/orderitemsummary/GovUkOrderItemSummaryView.ts
+++ b/src/orderitemsummary/GovUkOrderItemSummaryView.ts
@@ -1,0 +1,8 @@
+import { GovUkSummaryList } from "../govuk/GovUkSummaryList";
+
+export class GovUkOrderItemSummaryView {
+    orderId: string;
+    itemId: string;
+    itemDetails: GovUkSummaryList = new GovUkSummaryList();
+    backLinkUrl: string;
+}

--- a/src/orderitemsummary/MissingImageDeliveryMapper.ts
+++ b/src/orderitemsummary/MissingImageDeliveryMapper.ts
@@ -1,0 +1,94 @@
+import { OrderItemMapper } from "./OrderItemMapper";
+import { OrderItemView } from "./OrderItemView";
+import { GovUkOrderItemSummaryView } from "./GovUkOrderItemSummaryView";
+import { ItemOptions as MissingImageDeliveryItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/mid";
+import { MapperRequest } from "../mappers/MapperRequest";
+import { mapFilingHistory, mapFilingHistoryDate } from "./FilingHistoryMapper";
+
+export class MissingImageDeliveryMapper implements OrderItemMapper {
+    private readonly data: GovUkOrderItemSummaryView
+
+    constructor (private mapperRequest: MapperRequest) {
+        this.data = new GovUkOrderItemSummaryView();
+    }
+
+    map (): void {
+        this.data.orderId = this.mapperRequest.orderId;
+        this.data.itemId = this.mapperRequest.item.id;
+        this.mapItemDetails();
+        this.data.backLinkUrl = `/orders/${this.mapperRequest.orderId}`;
+    }
+
+    getMappedOrder (): OrderItemView {
+        return {
+            template: "order-item-summary-mid",
+            data: this.data
+        };
+    }
+
+    private mapItemDetails (): void {
+        const itemOptions = this.mapperRequest.item.itemOptions as MissingImageDeliveryItemOptions;
+        this.data.itemDetails.entries.push(
+            {
+                key: {
+                    classes: "govuk-!-width-one-third",
+                    text: "Company name"
+                },
+                value: {
+                    classes: "govuk-!-width-two-thirds",
+                    text: this.mapperRequest.item.companyName
+                }
+            },
+            {
+                key: {
+                    classes: "govuk-!-width-one-third",
+                    text: "Company number"
+                },
+                value: {
+                    classes: "govuk-!-width-two-thirds",
+                    text: this.mapperRequest.item.companyNumber
+                }
+            },
+            {
+                key: {
+                    classes: "govuk-!-width-one-third",
+                    text: "Date"
+                },
+                value: {
+                    classes: "govuk-!-width-two-thirds",
+                    text: mapFilingHistoryDate(itemOptions.filingHistoryDate)
+                }
+            },
+            {
+                key: {
+                    classes: "govuk-!-width-one-third",
+                    text: "Type"
+                },
+                value: {
+                    classes: "govuk-!-width-two-thirds",
+                    text: itemOptions.filingHistoryType
+                }
+            },
+            {
+                key: {
+                    classes: "govuk-!-width-one-third",
+                    text: "Description"
+                },
+                value: {
+                    classes: "govuk-!-width-two-thirds",
+                    text: mapFilingHistory(itemOptions.filingHistoryDescription, itemOptions.filingHistoryDescriptionValues)
+                }
+            },
+            {
+                key: {
+                    classes: "govuk-!-width-one-third",
+                    text: "Fee"
+                },
+                value: {
+                    classes: "govuk-!-width-two-thirds",
+                    text: `£${this.mapperRequest.item.totalItemCost}`
+                }
+            }
+        );
+    }
+}

--- a/src/orderitemsummary/NullOrderItemMapper.ts
+++ b/src/orderitemsummary/NullOrderItemMapper.ts
@@ -1,0 +1,12 @@
+import { OrderItemMapper } from "./OrderItemMapper";
+import { OrderItemView } from "./OrderItemView";
+
+export class NullOrderItemMapper implements OrderItemMapper {
+    getMappedOrder (): OrderItemView {
+        throw new Error("Mapper not found");
+    }
+
+    map (): void {
+        throw new Error("Mapper not found");
+    }
+}

--- a/src/orderitemsummary/OrderItemMapper.ts
+++ b/src/orderitemsummary/OrderItemMapper.ts
@@ -1,0 +1,6 @@
+import { OrderItemView } from "./OrderItemView";
+
+export interface OrderItemMapper {
+    map(): void;
+    getMappedOrder(): OrderItemView;
+}

--- a/src/orderitemsummary/OrderItemRequest.ts
+++ b/src/orderitemsummary/OrderItemRequest.ts
@@ -1,0 +1,5 @@
+export class OrderItemRequest {
+    apiToken: string;
+    orderId: string;
+    itemId: string;
+}

--- a/src/orderitemsummary/OrderItemSummaryController.ts
+++ b/src/orderitemsummary/OrderItemSummaryController.ts
@@ -1,0 +1,15 @@
+import { NextFunction, Request, Response } from "express";
+import { OrderItemSummaryService } from "./OrderItemSummaryService";
+import {createLogger} from "@companieshouse/structured-logging-node";
+
+
+export class OrderItemSummaryController {
+    private static readonly logger = createLogger("OrderItemSummaryController");
+
+    constructor (private service: OrderItemSummaryService = new OrderItemSummaryService()) {
+    }
+
+    async viewSummary (request: Request, response: Response, next: NextFunction): Promise<void> {
+
+    }
+}

--- a/src/orderitemsummary/OrderItemSummaryFactory.ts
+++ b/src/orderitemsummary/OrderItemSummaryFactory.ts
@@ -1,0 +1,8 @@
+import {OrderItemMapper} from "./OrderItemMapper";
+import {MapperRequest} from "../mappers/MapperRequest";
+
+export class OrderItemSummaryFactory {
+    getMapper (mapperRequest: MapperRequest): OrderItemMapper {
+        return undefined as any;
+    }
+}

--- a/src/orderitemsummary/OrderItemSummaryFactory.ts
+++ b/src/orderitemsummary/OrderItemSummaryFactory.ts
@@ -1,8 +1,14 @@
-import {OrderItemMapper} from "./OrderItemMapper";
-import {MapperRequest} from "../mappers/MapperRequest";
+import { OrderItemMapper } from "./OrderItemMapper";
+import { MapperRequest } from "../mappers/MapperRequest";
+import { MissingImageDeliveryMapper } from "./MissingImageDeliveryMapper";
+import { NullOrderItemMapper } from "./NullOrderItemMapper";
 
 export class OrderItemSummaryFactory {
     getMapper (mapperRequest: MapperRequest): OrderItemMapper {
-        return undefined as any;
+        if (mapperRequest.item.kind === "item#missing-image-delivery") {
+            return new MissingImageDeliveryMapper(mapperRequest);
+        } else {
+            return new NullOrderItemMapper();
+        }
     }
 }

--- a/src/orderitemsummary/OrderItemSummaryService.ts
+++ b/src/orderitemsummary/OrderItemSummaryService.ts
@@ -1,0 +1,12 @@
+import { OrderItemRequest } from "./OrderItemRequest";
+import { OrderItemView } from "./OrderItemView";
+import { OrderItemSummaryFactory } from "./OrderItemSummaryFactory";
+
+export class OrderItemSummaryService {
+    constructor(private factory: OrderItemSummaryFactory = new OrderItemSummaryFactory()) {
+    }
+
+    async getOrderItem (request: OrderItemRequest): Promise<OrderItemView> {
+        return undefined as any;
+    }
+}

--- a/src/orderitemsummary/OrderItemView.ts
+++ b/src/orderitemsummary/OrderItemView.ts
@@ -1,0 +1,4 @@
+export class OrderItemView {
+    template: string;
+    data: object;
+}

--- a/test/__mocks__/order.mocks.ts
+++ b/test/__mocks__/order.mocks.ts
@@ -1,0 +1,44 @@
+import { Item } from "@companieshouse/api-sdk-node/dist/services/order/order/types";
+
+export const mockMissingImageDeliveryItem: Item = {
+    id: "MID-123456-123456",
+    companyName: "The Company",
+    companyNumber: "00000000",
+    description: "missing image delivery for company 00000000",
+    descriptionIdentifier: "missing-image-delivery",
+    descriptionValues: {
+        company_number: "00000000",
+        "missing-image-delivery": "missing image delivery for company 00000000"
+    },
+    itemCosts: [
+        {
+            discountApplied: "0",
+            itemCost: "3",
+            calculatedCost: "3",
+            productType: "missing-image-delivery"
+        }
+    ],
+    itemOptions: {
+        filingHistoryBarcode: "barcode",
+        filingHistoryCategory: "category",
+        filingHistoryCost: "cost",
+        filingHistoryDate: "2015-05-26",
+        filingHistoryDescription: "appoint-person-director-company-with-name",
+        filingHistoryDescriptionValues: {
+            officer_name: "Mr Richard John Harris"
+        },
+        filingHistoryId: "MzEyMzcyNDc2OWFkaXF6a2N4",
+        filingHistoryType: "AP01"
+    },
+    etag: "7ae7d006fab4a6bab9fafcfea1eef1b78ffa4e52",
+    kind: "item#missing-image-delivery",
+    links: {
+        self: "/orderable/missing-image-deliveries/MID-123456-123456"
+    },
+    quantity: 1,
+    itemUri: "/orderable/missing-image-deliveries/MID-123456-123456",
+    status: "unknown",
+    postageCost: "0",
+    totalItemCost: "3",
+    postalDelivery: false
+};

--- a/test/orderitemsummary/MissingImageDeliveryMapper.unit.test.ts
+++ b/test/orderitemsummary/MissingImageDeliveryMapper.unit.test.ts
@@ -1,0 +1,92 @@
+import { MissingImageDeliveryMapper } from "../../src/orderitemsummary/MissingImageDeliveryMapper";
+import { OrderItemView } from "../../src/orderitemsummary/OrderItemView";
+import { expect } from "chai";
+import { MapperRequest } from "../../src/mappers/MapperRequest";
+import { GovUkOrderItemSummaryView } from "../../src/orderitemsummary/GovUkOrderItemSummaryView";
+import { mockMissingImageDeliveryItem } from "../__mocks__/order.mocks";
+
+describe("MissingImageDeliveryMapper", () => {
+    describe("map", () => {
+        it("Maps a mapper request for a missing image delivery item to a GovUkOrderItemSummaryView", async () => {
+            // given
+            const mapper: MissingImageDeliveryMapper = new MissingImageDeliveryMapper(new MapperRequest("ORD-123123-123123", mockMissingImageDeliveryItem));
+
+            // when
+            mapper.map();
+            const actual: OrderItemView = mapper.getMappedOrder();
+
+            // then
+            const mockMidOrderItemView: GovUkOrderItemSummaryView = {
+                orderId: "ORD-123123-123123",
+                itemId: "MID-123456-123456",
+                itemDetails: {
+                    entries: [
+                        {
+                            key: {
+                                classes: "govuk-!-width-one-third",
+                                text: "Company name"
+                            },
+                            value: {
+                                classes: "govuk-!-width-two-thirds",
+                                text: "The Company"
+                            }
+                        },
+                        {
+                            key: {
+                                classes: "govuk-!-width-one-third",
+                                text: "Company number"
+                            },
+                            value: {
+                                classes: "govuk-!-width-two-thirds",
+                                text: "00000000"
+                            }
+                        },
+                        {
+                            key: {
+                                classes: "govuk-!-width-one-third",
+                                text: "Date"
+                            },
+                            value: {
+                                classes: "govuk-!-width-two-thirds",
+                                text: "26 May 2015"
+                            }
+                        },
+                        {
+                            key: {
+                                classes: "govuk-!-width-one-third",
+                                text: "Type"
+                            },
+                            value: {
+                                classes: "govuk-!-width-two-thirds",
+                                text: "AP01"
+                            }
+                        },
+                        {
+                            key: {
+                                classes: "govuk-!-width-one-third",
+                                text: "Description"
+                            },
+                            value: {
+                                classes: "govuk-!-width-two-thirds",
+                                text: "Appointment of Mr Richard John Harris as a director"
+                            }
+                        },
+                        {
+                            key: {
+                                classes: "govuk-!-width-one-third",
+                                text: "Fee"
+                            },
+                            value: {
+                                classes: "govuk-!-width-two-thirds",
+                                text: "£3"
+                            }
+                        }
+                    ]
+                },
+                backLinkUrl: "/orders/ORD-123123-123123"
+            };
+            expect(actual.data).to.deep.equal(mockMidOrderItemView);
+            expect(actual.template).to.equal("order-item-summary-mid");
+        });
+    });
+});

--- a/test/orderitemsummary/OrderItemSummaryFactory.unit.test.ts
+++ b/test/orderitemsummary/OrderItemSummaryFactory.unit.test.ts
@@ -1,0 +1,33 @@
+import { OrderItemMapper } from "../../src/orderitemsummary/OrderItemMapper";
+import { OrderItemSummaryFactory } from "../../src/orderitemsummary/OrderItemSummaryFactory";
+import { Item } from "@companieshouse/api-sdk-node/dist/services/order/order/types";
+import { mockMissingImageDeliveryItem } from "../__mocks__/order.mocks";
+import { MissingImageDeliveryMapper } from "../../src/orderitemsummary/MissingImageDeliveryMapper";
+import { NullOrderItemMapper } from "../../src/orderitemsummary/NullOrderItemMapper";
+import { MapperRequest } from "../../src/mappers/MapperRequest";
+
+describe("OrderItemSummaryFactory", () => {
+    describe("getMapper", () => {
+        it("Returns a missing image delivery mapper for missing image delivery item kind", async () => {
+            // given
+            const factory = new OrderItemSummaryFactory();
+            // when
+            const mapper: OrderItemMapper = factory.getMapper(new MapperRequest("ORD-123123-123123", mockMissingImageDeliveryItem));
+            // then
+            expect(mapper).toBeInstanceOf(MissingImageDeliveryMapper);
+        });
+
+        it("Returns a null item mapper for unknown item kind", async () => {
+            // given
+            const factory = new OrderItemSummaryFactory();
+            const unknownCert: Item = {
+                ...mockMissingImageDeliveryItem,
+                kind: "unknown"
+            };
+            // when
+            const mapper: OrderItemMapper = factory.getMapper(new MapperRequest("ORD-123123-123123", unknownCert));
+            // then
+            expect(mapper).toBeInstanceOf(NullOrderItemMapper);
+        });
+    });
+});


### PR DESCRIPTION
* Add logic to OrderItemSummaryFactory to call respective MID mapper
* Use NullObject patternt and call NullOrderItemMapper if kind unknown
* Add FilingHistoryMapper for mapping filing history description and date values

Resolves [GCI-2309](https://companieshouse.atlassian.net/browse/GCI-2309)