### PR TITLE
GCI-2182 Implement order summary page

### DIFF
--- a/features/order_summary_page.feature
+++ b/features/order_summary_page.feature
@@ -1,0 +1,24 @@
+Feature: Order summary page
+  As a CHS Orders Admin user
+  I want to view a summary of an order
+  So I can see the items that make up that order
+
+  Scenario: View order summary
+    Given The checkout contains the following items:
+      | Missing image delivery                |
+      | Certificate with standard delivery    |
+      | Certificate with express delivery     |
+      | Certified copy with standard delivery |
+      | Certified copy with express delivery  |
+    When I view the order summary
+    Then The following items should be displayed:
+      | Item number       | Order type         | Company number | Delivery method | Fee |
+      | MID-123123-123123 | Missing image      | 12345678       | N/A             | £3  |
+      | CRT-123123-123123 | Certificate        | 12345678       | Standard        | £15 |
+      | CRT-123123-123124 | Certificate        | 12345678       | Express         | £50 |
+      | CCD-123123-123123 | Certified document | 12345678       | Standard        | £15 |
+      | CCD-123123-123124 | Certified document | 12345678       | Express         | £50 |
+    And Delivery details for the order should be "forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry"
+    And Payment details for the order should be:
+      | Payment reference | Fee  |
+      | F00DFACE          | £133 |

--- a/features/order_summary_page.feature
+++ b/features/order_summary_page.feature
@@ -41,3 +41,14 @@ Feature: Order summary page
     When I view the order summary
     Then The order summary page should display service unavailable
 
+  Scenario: User signs out
+    Given I am viewing an order summary
+    When I click sign out
+    Then I should be taken to the signout handler
+
+  Scenario: Click back button
+    Given Multi-item basket functionality has been enabled
+    And The order summary page will load successfully
+    And I have navigated to the order from the search page
+    When I click the back button on the order summary page
+    Then I should be returned from the order summary page to the orders search page

--- a/features/order_summary_page.feature
+++ b/features/order_summary_page.feature
@@ -15,11 +15,12 @@ Feature: Order summary page
       | Item number       | Order type         | Company number | Delivery method | Fee |
       | MID-123123-123123 | Missing image      | 12345678       | N/A             | £3  |
       | CRT-123123-123123 | Certificate        | 12345678       | Standard        | £15 |
-      | CRT-123123-123124 | Certificate        | 12345678       | Express         | £50 |
+      | CRT-123123-123124 | Certificate        | 12345679       | Express         | £50 |
       | CCD-123123-123123 | Certified document | 12345678       | Standard        | £15 |
-      | CCD-123123-123124 | Certified document | 12345678       | Express         | £50 |
+      | CCD-123123-123124 | Certified document | 12345670       | Express         | £50 |
     And Delivery details for the order should be:
-      | Delivery address | "forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry" |
+      | Delivery address                                                                      |
+      | Forename Surname\nAddress line 1\nAddress line 2\nLocality\nRegion\nPostcode\nCountry |
     And Payment details for the order should be:
       | Payment reference | Fee  |
-      | F00DFACE          | £133 |
+      | payment_reference | £133 |

--- a/features/order_summary_page.feature
+++ b/features/order_summary_page.feature
@@ -3,13 +3,8 @@ Feature: Order summary page
   I want to view a summary of an order
   So I can see the items that make up that order
 
-  Scenario: View order summary
-    Given The checkout contains the following items:
-      | Missing image delivery                |
-      | Certificate with standard delivery    |
-      | Certificate with express delivery     |
-      | Certified copy with standard delivery |
-      | Certified copy with express delivery  |
+  Scenario: Display item summaries, delivery details and payment details for known item types and delivery timescales
+    Given The checkout contains all known item types with all known delivery timescales
     When I view the order summary
     Then The following items should be displayed:
       | Item number       | Order type         | Company number | Delivery method | Fee |
@@ -24,3 +19,25 @@ Feature: Order summary page
     And Payment details for the order should be:
       | Payment reference | Fee  |
       | payment_reference | £133 |
+
+  Scenario: Hide the delivery details section if order contains no deliverable items
+    Given The checkout contains no deliverable items
+    When I view the order summary
+    Then The following items should be displayed:
+      | Item number       | Order type         | Company number | Delivery method | Fee |
+      | MID-123123-123123 | Missing image      | 12345678       | N/A             | £3  |
+    And Delivery details for the order should not be displayed
+    And Payment details for the order should be:
+      | Payment reference | Fee  |
+      | payment_reference | £3 |
+
+  Scenario: Display order not found if the order summary doesn't exist
+    Given The checkout does not exist
+    When I view the order summary
+    Then The order summary page should display order not found
+
+  Scenario: Display service unavailable if an error occurs when displaying the order summary
+    Given An error will occur when the checkout is fetched
+    When I view the order summary
+    Then The order summary page should display service unavailable
+

--- a/features/order_summary_page.feature
+++ b/features/order_summary_page.feature
@@ -18,7 +18,8 @@ Feature: Order summary page
       | CRT-123123-123124 | Certificate        | 12345678       | Express         | £50 |
       | CCD-123123-123123 | Certified document | 12345678       | Standard        | £15 |
       | CCD-123123-123124 | Certified document | 12345678       | Express         | £50 |
-    And Delivery details for the order should be "forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry"
+    And Delivery details for the order should be:
+      | Delivery address | "forename surname\naddress line 1\naddress line 2\nlocality\nregion\npostal code\ncountry" |
     And Payment details for the order should be:
       | Payment reference | Fee  |
       | F00DFACE          | £133 |

--- a/features/support/core/ZombieBrowserAgent.ts
+++ b/features/support/core/ZombieBrowserAgent.ts
@@ -18,7 +18,7 @@ export class ZombieBrowserAgent implements BrowserAgent, AgentService {
 
     async stop(): Promise<void> {
     }
-    
+
     async openPage(url: string): Promise<void> {
         if (this.browser == null) {
             throw new Error("Driver not started");
@@ -46,7 +46,7 @@ export class ZombieBrowserAgent implements BrowserAgent, AgentService {
             await this.browser.click(selector);
 
             if (element.href === "javascript:history.back()") {
-                this.openPage("/orders-admin/search");
+                await this.openPage("/orders-admin/search");
             }
         }
     }

--- a/features/support/order_summary/OrderSummaryPage.ts
+++ b/features/support/order_summary/OrderSummaryPage.ts
@@ -1,0 +1,94 @@
+import {OrderSummarySteps} from "./OrderSummarySteps";
+import {StubApiClientFactory} from "../../../dist/client/StubApiClientFactory";
+import successfulCheckoutResponse from "../stubbing/order_summary/checkout_with_all_item_combos.json";
+import {BrowserAgent} from "../core/BrowserAgent";
+import { expect } from "chai";
+
+export interface OrderSummaryPageState {
+    anticipateSuccessfulResponse(): Promise<void>;
+    openOrderSummaryPage(): Promise<void>;
+    verifyLayout(): Promise<void>;
+    verifyItems(expectedItems: string[][]): Promise<void>;
+    verifyDeliveryDetails(expectedDeliveryAddress: string): Promise<void>;
+    verifyPaymentDetails(expectedPaymentDetails: string[][]): Promise<void>;
+}
+
+export abstract class AbstractSummaryPage implements OrderSummaryPageState {
+    protected constructor(protected stateMachine: OrderSummarySteps) {
+    }
+
+    anticipateSuccessfulResponse(): Promise<void> {
+        throw new Error("Invalid operation");
+    }
+
+    openOrderSummaryPage(): Promise<void> {
+        throw new Error("Invalid operation");
+    }
+
+    verifyDeliveryDetails(expectedDeliveryAddress: string): Promise<void> {
+        throw new Error("Invalid operation");
+    }
+
+    verifyLayout(): Promise<void> {
+        throw new Error("Invalid operation");
+    }
+
+    verifyItems(expectedItems: string[][]): Promise<void> {
+        throw new Error("Invalid operation");
+    }
+
+    verifyPaymentDetails(expectedPaymentDetails: string[][]): Promise<void> {
+        throw new Error("Invalid operation");
+    }
+}
+
+export class NoPage extends AbstractSummaryPage {
+    constructor(stateMachine: OrderSummarySteps, private stubApiClient: StubApiClientFactory) {
+        super(stateMachine);
+    }
+
+    async anticipateSuccessfulResponse(): Promise<void> {
+        this.stubApiClient.willReturnSuccessfulCheckoutResponse(successfulCheckoutResponse);
+        this.stateMachine.currentPage = this.stateMachine.anticipateOrderSummary;
+    }
+}
+
+export class AnticipateOrderSummary extends AbstractSummaryPage {
+    constructor(stateMachine: OrderSummarySteps, private interactor: BrowserAgent) {
+        super(stateMachine);
+    }
+
+    async openOrderSummaryPage(): Promise<void> {
+        await this.interactor.openPage("/orders-admin/order-summaries/ORD-123123-123123");
+        this.stateMachine.currentPage = this.stateMachine.orderSummary;
+    }
+}
+
+export class OrderSummaryPage extends AbstractSummaryPage {
+    constructor(stateMachine: OrderSummarySteps, private interactor: BrowserAgent) {
+        super(stateMachine);
+    }
+
+    async verifyLayout(): Promise<void> {
+        expect(await this.interactor.getElementText("h1")).to.equal("ORD-123123-123123");
+    }
+
+    async verifyItems(expectedItems: string[][]): Promise<void> {
+        const resultsTable = await this.interactor.getTable(".govuk-table");
+        for (const [index, element] of resultsTable.tableRows.entries()) {
+            const linkable = expectedItems[index].pop();
+            expect(element.getValues()).to.deep.equal(expectedItems[index]);
+            expect(linkable).to.equal(element.linkable.toString());
+        }
+    }
+
+    async verifyDeliveryDetails(expectedDeliveryAddress: string): Promise<void> {
+        expect(await this.interactor.getElementText("#deliveryDetails")).to.contain(expectedDeliveryAddress);
+    }
+
+    async verifyPaymentDetails(expectedPaymentDetails: string[][]): Promise<void> {
+        const resultList = await this.interactor.getList("#paymentDetailsList");
+        expect(resultList.getNames()).to.deep.equal(expectedPaymentDetails[0]);
+        expect(resultList.getValues()).to.deep.equal(expectedPaymentDetails[1]);
+    }
+}

--- a/features/support/order_summary/OrderSummaryPage.ts
+++ b/features/support/order_summary/OrderSummaryPage.ts
@@ -8,6 +8,9 @@ export interface OrderSummaryPageState {
     anticipateClientError(json: any): Promise<void>;
     anticipateServerError(json: any): Promise<void>;
     openOrderSummaryPage(): Promise<void>;
+    openOrderSummaryPageViaLink(): Promise<void>;
+    clickBackLink(): Promise<void>;
+    clickSignOut(): Promise<void>;
     verifyLayout(): Promise<void>;
     verifyItems(expectedItems: string[][]): Promise<void>;
     verifyDeliveryDetails(expectedDeliveryDetails: string[][]): Promise<void>;
@@ -15,6 +18,7 @@ export interface OrderSummaryPageState {
     verifyPaymentDetails(expectedPaymentDetails: string[][]): Promise<void>;
     verifyNotFoundErrorDisplayed(): Promise<void>;
     verifyServiceUnavailableErrorDisplayed(): Promise<void>;
+    verifyLocation(expected: string): Promise<void>;
 }
 
 export abstract class AbstractSummaryPage implements OrderSummaryPageState {
@@ -34,6 +38,18 @@ export abstract class AbstractSummaryPage implements OrderSummaryPageState {
     }
 
     openOrderSummaryPage(): Promise<void> {
+        throw new Error("Invalid operation");
+    }
+
+    openOrderSummaryPageViaLink(): Promise<void> {
+        throw new Error("Invalid operation");
+    }
+
+    clickBackLink(): Promise<void> {
+        throw new Error("Invalid operation");
+    }
+
+    clickSignOut(): Promise<void> {
         throw new Error("Invalid operation");
     }
 
@@ -62,6 +78,10 @@ export abstract class AbstractSummaryPage implements OrderSummaryPageState {
     }
 
     verifyServiceUnavailableErrorDisplayed(): Promise<void> {
+        throw new Error("Invalid operation");
+    }
+
+    verifyLocation(expected: string): Promise<void> {
         throw new Error("Invalid operation");
     }
 }
@@ -96,11 +116,23 @@ export class AnticipateOrderSummary extends AbstractSummaryPage {
         await this.interactor.openPage("/orders-admin/order-summaries/ORD-123123-123123");
         this.stateMachine.currentPage = this.stateMachine.orderSummary;
     }
+
+    async openOrderSummaryPageViaLink(): Promise<void> {
+        this.stateMachine.currentPage = this.stateMachine.orderSummary;
+    }
 }
 
 export class OrderSummaryPage extends AbstractSummaryPage {
     constructor(stateMachine: OrderSummarySteps, private interactor: BrowserAgent) {
         super(stateMachine);
+    }
+
+    async clickBackLink(): Promise<void> {
+        await this.interactor.clickElement(".govuk-back-link");
+    }
+
+    async clickSignOut(): Promise<void> {
+        await this.interactor.clickElement(".sign-out-link");
     }
 
     async verifyLayout(): Promise<void> {
@@ -140,5 +172,9 @@ export class OrderSummaryPage extends AbstractSummaryPage {
     async verifyServiceUnavailableErrorDisplayed(): Promise<void> {
         const headingText = await this.interactor.getElementText("h1");
         expect(headingText).to.equal("Service unavailable");
+    }
+
+    async verifyLocation(expected: string): Promise<void> {
+        expect(await this.interactor.getLocation()).to.equal(expected);
     }
 }

--- a/features/support/order_summary/OrderSummaryPage.ts
+++ b/features/support/order_summary/OrderSummaryPage.ts
@@ -76,9 +76,7 @@ export class OrderSummaryPage extends AbstractSummaryPage {
     async verifyItems(expectedItems: string[][]): Promise<void> {
         const resultsTable = await this.interactor.getTable(".govuk-table");
         for (const [index, element] of resultsTable.tableRows.entries()) {
-            const linkable = expectedItems[index].pop();
             expect(element.getValues()).to.deep.equal(expectedItems[index]);
-            expect(linkable).to.equal(element.linkable.toString());
         }
     }
 

--- a/features/support/order_summary/OrderSummaryPage.ts
+++ b/features/support/order_summary/OrderSummaryPage.ts
@@ -9,12 +9,12 @@ export interface OrderSummaryPageState {
     openOrderSummaryPage(): Promise<void>;
     verifyLayout(): Promise<void>;
     verifyItems(expectedItems: string[][]): Promise<void>;
-    verifyDeliveryDetails(expectedDeliveryAddress: string): Promise<void>;
+    verifyDeliveryDetails(expectedDeliveryDetails: string[][]): Promise<void>;
     verifyPaymentDetails(expectedPaymentDetails: string[][]): Promise<void>;
 }
 
 export abstract class AbstractSummaryPage implements OrderSummaryPageState {
-    protected constructor(protected stateMachine: OrderSummarySteps) {
+    constructor(protected stateMachine: OrderSummarySteps) {
     }
 
     anticipateSuccessfulResponse(): Promise<void> {
@@ -25,7 +25,7 @@ export abstract class AbstractSummaryPage implements OrderSummaryPageState {
         throw new Error("Invalid operation");
     }
 
-    verifyDeliveryDetails(expectedDeliveryAddress: string): Promise<void> {
+    verifyDeliveryDetails(expectedDeliveryDetails: string[][]): Promise<void> {
         throw new Error("Invalid operation");
     }
 
@@ -82,8 +82,10 @@ export class OrderSummaryPage extends AbstractSummaryPage {
         }
     }
 
-    async verifyDeliveryDetails(expectedDeliveryAddress: string): Promise<void> {
-        expect(await this.interactor.getElementText("#deliveryDetails")).to.contain(expectedDeliveryAddress);
+    async verifyDeliveryDetails(expectedDeliveryDetails: string[][]): Promise<void> {
+        const resultList = await this.interactor.getList("#deliveryDetailsList");
+        expect(resultList.getNames()).to.deep.equal(expectedDeliveryDetails[0]);
+        expect(resultList.getValues()).to.deep.equal(expectedDeliveryDetails[1]);
     }
 
     async verifyPaymentDetails(expectedPaymentDetails: string[][]): Promise<void> {

--- a/features/support/order_summary/OrderSummarySteps.ts
+++ b/features/support/order_summary/OrderSummarySteps.ts
@@ -1,0 +1,46 @@
+import "reflect-metadata";
+import {binding, given, then, when} from "cucumber-tsflow/dist";
+import {AnticipateOrderSummary, NoPage, OrderSummaryPage, OrderSummaryPageState} from "./OrderSummaryPage";
+import {DataTable} from "@cucumber/cucumber";
+import {BrowserAgent} from "../core/BrowserAgent";
+import Container from "typedi";
+import {StubApiClientFactory} from "../../../dist/client/StubApiClientFactory";
+
+@binding()
+export class OrderSummarySteps {
+    readonly anticipateOrderSummary: OrderSummaryPageState;
+    readonly orderSummary: OrderSummaryPageState;
+
+    currentPage: OrderSummaryPageState;
+
+    constructor(browserAgent: BrowserAgent = Container.get(process.env.agent || "selenium"), apiFactory: StubApiClientFactory = Container.get("stub.client")) {
+        this.anticipateOrderSummary = new AnticipateOrderSummary(this, browserAgent);
+        this.orderSummary = new OrderSummaryPage(this, browserAgent);
+        this.currentPage = new NoPage(this, apiFactory);
+    }
+
+    @given(/^The checkout contains the following items:$/)
+    async checkoutResourceContainsItems(expectedItems: DataTable) {
+        await this.currentPage.anticipateSuccessfulResponse();
+    }
+
+    @when(/^I view the order summary$/)
+    async viewOrderSummary() {
+        await this.currentPage.openOrderSummaryPage();
+    }
+
+    @then(/^The following items should be displayed:$/)
+    async verifyItemsDisplayed(expectedItems: DataTable) {
+        await this.currentPage.verifyItems(expectedItems.rows())
+    }
+
+    @then(/^Delivery details for the order should be "(.+?)"$/)
+    async verifyDeliveryDetailsDisplayed(expectedDeliveryDetails: string) {
+        await this.currentPage.verifyDeliveryDetails(expectedDeliveryDetails);
+    }
+
+    @then(/Payment details for the order should be:/)
+    async verifyPaymentDetails(expectedPaymentDetails: DataTable) {
+        await this.currentPage.verifyPaymentDetails(expectedPaymentDetails.raw());
+    }
+}

--- a/features/support/order_summary/OrderSummarySteps.ts
+++ b/features/support/order_summary/OrderSummarySteps.ts
@@ -34,9 +34,9 @@ export class OrderSummarySteps {
         await this.currentPage.verifyItems(expectedItems.rows())
     }
 
-    @then(/^Delivery details for the order should be "(.+?)"$/)
-    async verifyDeliveryDetailsDisplayed(expectedDeliveryDetails: string) {
-        await this.currentPage.verifyDeliveryDetails(expectedDeliveryDetails);
+    @then(/^Delivery details for the order should be:$/)
+    async verifyDeliveryDetailsDisplayed(expectedDeliveryDetails: DataTable) {
+        await this.currentPage.verifyDeliveryDetails(expectedDeliveryDetails.raw());
     }
 
     @then(/Payment details for the order should be:/)

--- a/features/support/order_summary/OrderSummarySteps.ts
+++ b/features/support/order_summary/OrderSummarySteps.ts
@@ -5,6 +5,8 @@ import {DataTable} from "@cucumber/cucumber";
 import {BrowserAgent} from "../core/BrowserAgent";
 import Container from "typedi";
 import {StubApiClientFactory} from "../../../dist/client/StubApiClientFactory";
+import successfulCheckoutResponse from "../stubbing/order_summary/checkout_with_all_item_combos.json";
+import checkoutNoDeliverableItems from "../stubbing/order_summary/checkout_with_no_deliverable_items.json";
 
 @binding()
 export class OrderSummarySteps {
@@ -19,9 +21,28 @@ export class OrderSummarySteps {
         this.currentPage = new NoPage(this, apiFactory);
     }
 
-    @given(/^The checkout contains the following items:$/)
-    async checkoutResourceContainsItems(expectedItems: DataTable) {
-        await this.currentPage.anticipateSuccessfulResponse();
+    @given(/^The checkout contains all known item types with all known delivery timescales$/)
+    async checkoutResourceContainsItems() {
+        await this.currentPage.anticipateSuccessfulResponse(successfulCheckoutResponse);
+    }
+
+    @given(/^The checkout contains no deliverable items$/)
+    async checkoutResourceContainsNoDeliverableItemsItems() {
+        await this.currentPage.anticipateSuccessfulResponse(checkoutNoDeliverableItems);
+    }
+
+    @given(/^The checkout does not exist$/)
+    async checkoutResourceNonexistent() {
+        await this.currentPage.anticipateClientError({
+            error: "Not found"
+        });
+    }
+
+    @given(/^An error will occur when the checkout is fetched$/)
+    async checkoutResourceErrors() {
+        await this.currentPage.anticipateServerError({
+            error: "Something went wrong"
+        });
     }
 
     @when(/^I view the order summary$/)
@@ -39,8 +60,23 @@ export class OrderSummarySteps {
         await this.currentPage.verifyDeliveryDetails(expectedDeliveryDetails.raw());
     }
 
+    @then(/^Delivery details for the order should not be displayed$/)
+    async verifyDeliveryDetailsNotDisplayed() {
+        await this.currentPage.verifyNoDeliveryDetailsDisplayed();
+    }
+
     @then(/Payment details for the order should be:/)
     async verifyPaymentDetails(expectedPaymentDetails: DataTable) {
         await this.currentPage.verifyPaymentDetails(expectedPaymentDetails.raw());
+    }
+
+    @then(/The order summary page should display order not found/)
+    async verifyOrderNotFoundDisplayed() {
+        await this.currentPage.verifyNotFoundErrorDisplayed();
+    }
+
+    @then(/The order summary page should display service unavailable/)
+    async verifyServiceUnavailableDisplayed() {
+        await this.currentPage.verifyServiceUnavailableErrorDisplayed();
     }
 }

--- a/features/support/order_summary/OrderSummarySteps.ts
+++ b/features/support/order_summary/OrderSummarySteps.ts
@@ -45,9 +45,26 @@ export class OrderSummarySteps {
         });
     }
 
+    @given(/^I am viewing an order summary$/)
+    async harnessAndViewOrderSummary() {
+        await this.checkoutResourceContainsItems();
+        await this.currentPage.openOrderSummaryPage();
+    }
+
+    @given(/^The order summary page will load successfully$/)
+    async harnessAndAutotransition() {
+        await this.checkoutResourceContainsItems();
+        await this.currentPage.openOrderSummaryPageViaLink();
+    }
+
     @when(/^I view the order summary$/)
     async viewOrderSummary() {
         await this.currentPage.openOrderSummaryPage();
+    }
+
+    @when(/^I click the back button on the order summary page$/)
+    async clickBackButton() {
+        await this.currentPage.clickBackLink();
     }
 
     @then(/^The following items should be displayed:$/)
@@ -78,5 +95,10 @@ export class OrderSummarySteps {
     @then(/The order summary page should display service unavailable/)
     async verifyServiceUnavailableDisplayed() {
         await this.currentPage.verifyServiceUnavailableErrorDisplayed();
+    }
+
+    @then(/I should be returned from the order summary page to the orders search page/)
+    async verifyLocationIsSearch() {
+        await this.currentPage.verifyLocation("/orders-admin/search");
     }
 }

--- a/features/support/search/SearchSteps.ts
+++ b/features/support/search/SearchSteps.ts
@@ -9,6 +9,7 @@ import {
     AnticipateResultsPage, AnticipateNoResultsPage, AnticipateErrorPage
 } from "./SearchPage";
 import Container from "typedi";
+import "../order_summary/OrderSummarySteps";
 import "reflect-metadata";
 import {BrowserAgent} from "../core/BrowserAgent";
 import {DataTable} from "@cucumber/cucumber";
@@ -121,6 +122,14 @@ export class SearchSteps {
         await this.currentPage.clickSearch();
         await this.currentPage.verifyLayout();
         await this.currentPage.verifyMatchingOrdersDisplayed(results.rows());
+        await this.currentPage.clickLinkableCertificate();
+    }
+
+    @given(/^I have navigated to the order from the search page$/)
+    public async navigateToOrderFromSearchPage() {
+        await this.currentPage.openSearchPage();
+        await this.currentPage.harnessOrdersApiWithResults();
+        await this.currentPage.clickSearch();
         await this.currentPage.clickLinkableCertificate();
     }
 

--- a/features/support/stubbing/order_summary/checkout_with_all_item_combos.json
+++ b/features/support/stubbing/order_summary/checkout_with_all_item_combos.json
@@ -1,0 +1,299 @@
+{
+  "payment_reference": "payment_reference",
+  "etag": "F00DFACE",
+  "delivery_details": {
+    "country": "Country",
+    "forename": "Forename",
+    "locality": "Locality",
+    "postal_code": "Postcode",
+    "region": "Region",
+    "surname": "Surname",
+    "address_line_1": "Address line 1",
+    "address_line_2": "Address line 2"
+  },
+  "items": [
+    {
+      "id": "MID-123123-123123",
+      "company_name": "The Company",
+      "company_number": "00000000",
+      "description": "missing image delivery for company 00000000",
+      "description_identifier": "missing-image-delivery",
+      "description_values": {
+        "company_number": "00000000",
+        "missing-image-delivery": "missing image delivery for company 00000000"
+      },
+      "item_costs": [
+        {
+          "discountApplied": "0",
+          "itemCost": "3",
+          "calculatedCost": "3",
+          "productType": "missing-image-delivery"
+        }
+      ],
+      "itemOptions": {
+        "filingHistoryBarcode": "barcode",
+        "filingHistoryCategory": "category",
+        "filingHistoryCost": "cost",
+        "filingHistoryDate": "2015-05-26",
+        "filingHistoryDescription": "appoint-person-director-company-with-name",
+        "filingHistoryDescriptionValues": {
+          "officer_name": "Mr Richard John Harris"
+        },
+        "filingHistoryId": "MzEyMzcyNDc2OWFkaXF6a2N4",
+        "filingHistoryType": "AP01"
+      },
+      "etag": "7ae7d006fab4a6bab9fafcfea1eef1b78ffa4e52",
+      "kind": "item#missing-image-delivery",
+      "links": {
+        "self": "/orderable/missing-image-deliveries/MID-123123-123123"
+      },
+      "quantity": 1,
+      "itemUri": "/orderable/missing-image-deliveries/MID-123123-123123",
+      "status": "unknown",
+      "postageCost": "0",
+      "totalItemCost": "3",
+      "postalDelivery": false
+    },
+    {
+      "id": "CRT-123123-123123",
+      "company_name": "TEST COMPANY LIMITED",
+      "company_number": "12345678",
+      "customer_reference": "customer reference",
+      "description": "certificate for company 00000000",
+      "description_identifier": "certificate",
+      "description_values": {
+        "certificate": "certificate for company 00000000",
+        "company_number": "00000000"
+      },
+      "item_costs": [
+        {
+          "discount_applied": "0",
+          "item_cost": "15",
+          "calculated_cost": "15",
+          "product_type": "certificate"
+        }
+      ],
+      "item_options": {
+        "collection_location": "collection location",
+        "contact_number": "0",
+        "delivery_method": "collection",
+        "delivery_timescale": "standard",
+        "forename": "forename",
+        "surname": "surname",
+        "certificate_type": "incorporation-with-all-name-changes",
+        "director_details": {
+          "include_address": false,
+          "include_appointment_date": false,
+          "include_basic_information": true,
+          "include_country_of_residence": false,
+          "include_nationality": false,
+          "include_occupation": false
+        },
+        "include_company_objects_information": true,
+        "include_email_copy": false,
+        "include_good_standing_information": true,
+        "registered_office_address_details": {
+          "include_address_records_type": "all",
+          "include_dates": false
+        },
+        "secretary_details": {
+          "include_address": false,
+          "include_appointment_date": false,
+          "include_basic_information": true
+        },
+        "company_type": "ltd",
+        "company_status": "active"
+      },
+      "etag": "F00DFACE",
+      "kind": "item#certificate",
+      "links": {
+        "self": "/orderable/certificates/CRT-123123-123123"
+      },
+      "quantity": 1,
+      "item_uri": "/orderable/certificates/CRT-123123-123123",
+      "status": "unknown",
+      "postage_cost": "0",
+      "total_item_cost": "15",
+      "postal_delivery": true
+    },
+    {
+      "id": "CRT-123123-123124",
+      "company_name": "TEST COMPANY 2 LIMITED",
+      "company_number": "12345679",
+      "customer_reference": "customer reference",
+      "description": "certificate for company 12345679",
+      "description_identifier": "certificate",
+      "description_values": {
+        "certificate": "certificate for company 12345679",
+        "company_number": "12345679"
+      },
+      "item_costs": [
+        {
+          "discount_applied": "0",
+          "item_cost": "15",
+          "calculated_cost": "15",
+          "product_type": "certificate"
+        }
+      ],
+      "item_options": {
+        "collection_location": "collection location",
+        "contact_number": "0",
+        "delivery_method": "collection",
+        "delivery_timescale": "same-day",
+        "forename": "forename",
+        "surname": "surname",
+        "certificate_type": "incorporation-with-all-name-changes",
+        "director_details": {
+          "include_address": false,
+          "include_appointment_date": false,
+          "include_basic_information": true,
+          "include_country_of_residence": false,
+          "include_nationality": false,
+          "include_occupation": false
+        },
+        "include_company_objects_information": true,
+        "include_email_copy": false,
+        "include_good_standing_information": true,
+        "registered_office_address_details": {
+          "include_address_records_type": "all",
+          "include_dates": false
+        },
+        "secretary_details": {
+          "include_address": false,
+          "include_appointment_date": false,
+          "include_basic_information": true
+        },
+        "company_type": "ltd",
+        "company_status": "active"
+      },
+      "etag": "F00DFACE",
+      "kind": "item#certificate",
+      "links": {
+        "self": "/orderable/certificates/CRT-123123-123124"
+      },
+      "quantity": 1,
+      "item_uri": "/orderable/certificates/CRT-123123-123124",
+      "status": "unknown",
+      "postage_cost": "0",
+      "total_item_cost": "50",
+      "postal_delivery": true
+    },
+    {
+      "id": "CCD-123123-123123",
+      "company_name": "COMPANY NAME LIMITED",
+      "company_number": "12345678",
+      "description": "certified copy for company 12345678",
+      "description_identifier": "certified-copy",
+      "description_values": {
+        "company_number": "12345678",
+        "certified-copy": "certified copy for company 12345678"
+      },
+      "item_costs": [
+        {
+          "discount_applied": "0",
+          "item_cost": "15",
+          "calculated_cost": "15",
+          "product_type": "certified-copy"
+        }
+      ],
+      "item_options": {
+        "delivery_method": "postal",
+        "delivery_timescale": "standard",
+        "filing_history_documents": [
+          {
+            "filing_history_date": "2022-05-12",
+            "filing_history_description": "capital-allotment-shares",
+            "filing_history_description_values": {
+              "date": "2022-05-12",
+              "capital": [
+                {
+                  "figure": "12,345,678",
+                  "currency": "GBP"
+                }
+              ]
+            },
+            "filing_history_id": "CAFE",
+            "filing_history_type": "SH01",
+            "filing_history_cost": "15"
+          }
+        ]
+      },
+      "etag": "F00DFACE",
+      "kind": "item#certified-copy",
+      "links": {
+        "self": "/orderable/certified-copies/CCD-123123-123123"
+      },
+      "quantity": 1,
+      "item_uri": "/orderable/certified-copies/CCD-123123-123123",
+      "status": "unknown",
+      "postage_cost": "0",
+      "total_item_cost": "15",
+      "postal_delivery": true
+    },
+    {
+      "id": "CCD-123123-123124",
+      "company_name": "COMPANY NAME 2 LIMITED",
+      "company_number": "12345670",
+      "description": "certified copy for company 12345670",
+      "description_identifier": "certified-copy",
+      "description_values": {
+        "company_number": "12345670",
+        "certified-copy": "certified copy for company 12345670"
+      },
+      "item_costs": [
+        {
+          "discount_applied": "0",
+          "item_cost": "15",
+          "calculated_cost": "15",
+          "product_type": "certified-copy"
+        }
+      ],
+      "item_options": {
+        "delivery_method": "postal",
+        "delivery_timescale": "same-day",
+        "filing_history_documents": [
+          {
+            "filing_history_date": "2022-05-12",
+            "filing_history_description": "capital-allotment-shares",
+            "filing_history_description_values": {
+              "date": "2022-05-12",
+              "capital": [
+                {
+                  "figure": "12,345,678",
+                  "currency": "GBP"
+                }
+              ]
+            },
+            "filing_history_id": "CAFE",
+            "filing_history_type": "SH01",
+            "filing_history_cost": "15"
+          }
+        ]
+      },
+      "etag": "F00DFACE",
+      "kind": "item#certified-copy",
+      "links": {
+        "self": "/orderable/certified-copies/CCD-123123-123124"
+      },
+      "quantity": 1,
+      "item_uri": "/orderable/certified-copies/CCD-123123-123124",
+      "status": "unknown",
+      "postage_cost": "0",
+      "total_item_cost": "50",
+      "postal_delivery": true
+    }
+  ],
+  "kind": "order",
+  "total_order_cost": "133",
+  "reference": "ORD-123123-123123",
+  "paid_at": "2022-05-02T12:00:00.000",
+  "checked_out_by": {
+    "email": "demo@ch.gov.uk",
+    "id": "F00DFACE"
+  },
+  "status": "paid",
+  "links": {
+    "self": "/basket/checkouts/ORD-123123-123123",
+    "payment": "/basket/checkouts/ORD-123123-123123/payment"
+  }
+}

--- a/features/support/stubbing/order_summary/checkout_with_no_deliverable_items.json
+++ b/features/support/stubbing/order_summary/checkout_with_no_deliverable_items.json
@@ -1,0 +1,71 @@
+{
+  "payment_reference": "payment_reference",
+  "etag": "F00DFACE",
+  "delivery_details": {
+    "country": "Country",
+    "forename": "Forename",
+    "locality": "Locality",
+    "postal_code": "Postcode",
+    "region": "Region",
+    "surname": "Surname",
+    "address_line_1": "Address line 1",
+    "address_line_2": "Address line 2"
+  },
+  "items": [
+    {
+      "id": "MID-123123-123123",
+      "company_name": "The Company",
+      "company_number": "12345678",
+      "description": "missing image delivery for company 00000000",
+      "description_identifier": "missing-image-delivery",
+      "description_values": {
+        "company_number": "12345678",
+        "missing-image-delivery": "missing image delivery for company 12345678"
+      },
+      "item_costs": [
+        {
+          "discountApplied": "0",
+          "itemCost": "3",
+          "calculatedCost": "3",
+          "productType": "missing-image-delivery"
+        }
+      ],
+      "itemOptions": {
+        "filingHistoryBarcode": "barcode",
+        "filingHistoryCategory": "category",
+        "filingHistoryCost": "cost",
+        "filingHistoryDate": "2015-05-26",
+        "filingHistoryDescription": "appoint-person-director-company-with-name",
+        "filingHistoryDescriptionValues": {
+          "officer_name": "Mr Richard John Harris"
+        },
+        "filingHistoryId": "MzEyMzcyNDc2OWFkaXF6a2N4",
+        "filingHistoryType": "AP01"
+      },
+      "etag": "7ae7d006fab4a6bab9fafcfea1eef1b78ffa4e52",
+      "kind": "item#missing-image-delivery",
+      "links": {
+        "self": "/orderable/missing-image-deliveries/MID-123123-123123"
+      },
+      "quantity": 1,
+      "itemUri": "/orderable/missing-image-deliveries/MID-123123-123123",
+      "status": "unknown",
+      "postageCost": "0",
+      "totalItemCost": "3",
+      "postalDelivery": false
+    }
+  ],
+  "kind": "order",
+  "total_order_cost": "3",
+  "reference": "ORD-123123-123123",
+  "paid_at": "2022-05-02T12:00:00.000",
+  "checked_out_by": {
+    "email": "demo@ch.gov.uk",
+    "id": "F00DFACE"
+  },
+  "status": "paid",
+  "links": {
+    "self": "/basket/checkouts/ORD-123123-123123",
+    "payment": "/basket/checkouts/ORD-123123-123123/payment"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1218,7 +1218,7 @@
         "@types/node": "*",
         "@types/node-sass": "*"
       }
-    }, d
+    },
     "@types/http-errors": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.6.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1218,6 +1218,12 @@
         "@types/node": "*",
         "@types/node-sass": "*"
       }
+    }, d
+    "@types/http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha512-4KCE/agIcoQ9bIfa4sBxbZdnORzRjIw8JNQPLfqoNv7wQl/8f8mRbW68Q8wBsQFoJkPUHGlQYZ9sqi5WpfGSEQ==",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -5374,7 +5380,7 @@
     "http-errors": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -9250,9 +9256,9 @@
       }
     },
     "statuses": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
     },
     "stealthy-require": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "clean": "rm -rf ./dist",
     "test": "npx jest --verbose",
     "coverage": "npx jest --verbose --coverage",
-    "test-integration": "agent=zombie ADMIN_ORDERS_DEVELOPMENT_MODE=true npx cucumber-js",
-    "test-automation": "agent=selenium ADMIN_ORDERS_DEVELOPMENT_MODE=true npx cucumber-js",
+    "test-integration": "agent=zombie ADMIN_ORDERS_DEVELOPMENT_MODE=true npx --node-arg=\"--inspect-brk\" cucumber-js",
+    "test-automation": "agent=selenium ADMIN_ORDERS_DEVELOPMENT_MODE=true npx --node-arg=\"--inspect-brk\" cucumber-js",
     "sonarqube": "sonar-scanner"
   },
   "dependencies": {
@@ -39,6 +39,7 @@
     "@types/express": "^4.17.13",
     "@types/gulp": "^4.0.9",
     "@types/gulp-sass": "^5.0.0",
+    "@types/http-errors": "~1.6.3",
     "@types/jest": "^27.4.1",
     "@types/node": "^11.15.54",
     "@types/sass": "^1.43.1",

--- a/src/application/Registrar.ts
+++ b/src/application/Registrar.ts
@@ -7,6 +7,7 @@ import {SearchController} from "../search/SearchController";
 import "../security/MiddlewareProvider";
 import { OrderDetailsController } from "../orderdetails/OrderDetailsController";
 import {OrderSummaryController} from "../order_summary/OrderSummaryController";
+import {FEATURE_FLAGS} from "../config/FeatureOptions";
 
 @Service()
 export class Registrar {
@@ -23,7 +24,9 @@ export class Registrar {
         this.app.bindGet(this.serverPaths.webContextPath + "/search", this.searchController.handleGet.bind(this.searchController), this.middlewareProvider.middlewareables);
         this.app.bindPost(this.serverPaths.webContextPath + "/search", this.searchController.handlePost.bind(this.searchController), this.middlewareProvider.middlewareables);
         this.app.bindGet(this.serverPaths.webContextPath + "/orders/:orderId", this.orderDetailsController.handleGet.bind(this.orderDetailsController), this.middlewareProvider.middlewareables);
-        this.app.bindGet(this.serverPaths.webContextPath + "/order-summaries/:orderId", this.orderSummaryController.readOrder.bind(this.orderSummaryController), this.middlewareProvider.middlewareables);
+        if (FEATURE_FLAGS.multiItemBasketEnabled) {
+            this.app.bindGet(this.serverPaths.webContextPath + "/order-summaries/:orderId", this.orderSummaryController.readOrder.bind(this.orderSummaryController), this.middlewareProvider.middlewareables);
+        }
         this.app.start();
     }
 

--- a/src/application/Registrar.ts
+++ b/src/application/Registrar.ts
@@ -6,6 +6,7 @@ import { ServerPaths } from "./ServerPaths";
 import {SearchController} from "../search/SearchController";
 import "../security/MiddlewareProvider";
 import { OrderDetailsController } from "../orderdetails/OrderDetailsController";
+import {OrderSummaryController} from "../order_summary/OrderSummaryController";
 
 @Service()
 export class Registrar {
@@ -13,14 +14,16 @@ export class Registrar {
                 @Inject((process.env.ADMIN_ORDERS_DEVELOPMENT_MODE === "true" ? "noop.middleware" : "production.middleware")) private readonly middlewareProvider: MiddlewareProvider,
                 private readonly serverPaths: ServerPaths,
                 private readonly searchController: SearchController,
-                private readonly orderDetailsController: OrderDetailsController) {
+                private readonly orderDetailsController: OrderDetailsController,
+                private readonly orderSummaryController: OrderSummaryController) {
     }
 
     public start(): void {
         this.app.bindGet("/signout", async (req, res, next): Promise<void> => { res.status(200).send(); }, []);
         this.app.bindGet(this.serverPaths.webContextPath + "/search", this.searchController.handleGet.bind(this.searchController), this.middlewareProvider.middlewareables);
         this.app.bindPost(this.serverPaths.webContextPath + "/search", this.searchController.handlePost.bind(this.searchController), this.middlewareProvider.middlewareables);
-        this.app.bindGet(this.serverPaths.webContextPath + "/orders/:orderId", this.orderDetailsController.handleGet.bind(this.orderDetailsController), this.middlewareProvider.middlewareables)
+        this.app.bindGet(this.serverPaths.webContextPath + "/orders/:orderId", this.orderDetailsController.handleGet.bind(this.orderDetailsController), this.middlewareProvider.middlewareables);
+        this.app.bindGet(this.serverPaths.webContextPath + "/order-summaries/:orderId", this.orderSummaryController.readOrder.bind(this.orderSummaryController), this.middlewareProvider.middlewareables);
         this.app.start();
     }
 

--- a/src/application/Registrar.ts
+++ b/src/application/Registrar.ts
@@ -24,9 +24,7 @@ export class Registrar {
         this.app.bindGet(this.serverPaths.webContextPath + "/search", this.searchController.handleGet.bind(this.searchController), this.middlewareProvider.middlewareables);
         this.app.bindPost(this.serverPaths.webContextPath + "/search", this.searchController.handlePost.bind(this.searchController), this.middlewareProvider.middlewareables);
         this.app.bindGet(this.serverPaths.webContextPath + "/orders/:orderId", this.orderDetailsController.handleGet.bind(this.orderDetailsController), this.middlewareProvider.middlewareables);
-        if (FEATURE_FLAGS.multiItemBasketEnabled) {
-            this.app.bindGet(this.serverPaths.webContextPath + "/order-summaries/:orderId", this.orderSummaryController.readOrder.bind(this.orderSummaryController), this.middlewareProvider.middlewareables);
-        }
+        this.app.bindGet(this.serverPaths.webContextPath + "/order-summaries/:orderId", this.orderSummaryController.readOrder.bind(this.orderSummaryController), this.middlewareProvider.middlewareables);
         this.app.start();
     }
 

--- a/src/core/MapperRequest.ts
+++ b/src/core/MapperRequest.ts
@@ -1,0 +1,6 @@
+import { Item } from "@companieshouse/api-sdk-node/dist/services/order/order/types";
+
+export class MapperRequest {
+    constructor (public orderId: string, public item: Item) {
+    }
+}

--- a/src/govuk/GovUkSummaryList.ts
+++ b/src/govuk/GovUkSummaryList.ts
@@ -1,0 +1,14 @@
+export class GovUkSummaryList {
+    entries: GovUkSummaryListEntry[] = [];
+}
+
+export class GovUkSummaryListEntry {
+    key?: GovUkSummaryListObject;
+    value?: GovUkSummaryListObject;
+}
+
+export class GovUkSummaryListObject {
+    classes?: string;
+    text?: string;
+    html?: string;
+}

--- a/src/govuk/GovUkTableCell.ts
+++ b/src/govuk/GovUkTableCell.ts
@@ -1,0 +1,4 @@
+export class GovUkTableCell {
+    text?: string | null | undefined;
+    html?: string | null | undefined;
+}

--- a/src/order_summary/OrderSummary.ts
+++ b/src/order_summary/OrderSummary.ts
@@ -1,0 +1,25 @@
+export class OrderSummary {
+    public orderReference?: string;
+    public itemSummary: ItemSummary[] = [];
+    public hasDeliverableItems: boolean = false;
+    public deliveryDetails?: DeliveryDetails;
+    public paymentDetails?: PaymentDetails;
+    public backLinkUrl?: string;
+}
+
+export class ItemSummary {
+    public id?: string;
+    public orderType?: string;
+    public companyNumber?: string;
+    public deliveryMethod?: string;
+    public fee?: string;
+}
+
+export class PaymentDetails {
+    public paymentReference?: string;
+    public amountPaid?: string;
+}
+
+export class DeliveryDetails {
+    public deliveryAddress?: string;
+}

--- a/src/order_summary/OrderSummaryController.ts
+++ b/src/order_summary/OrderSummaryController.ts
@@ -1,0 +1,47 @@
+import {NextFunction, Request, Response} from "express";
+import {OrderSummaryService} from "./OrderSummaryService";
+import {createLogger} from "@companieshouse/structured-logging-node";
+import {Inject, Service} from "typedi";
+import {PageFactory} from "./PageFactory";
+import {Status} from "../core/Status";
+import "reflect-metadata";
+import {BACK_LINK_TOGGLER} from "../config/BackLinkToggler";
+
+@Service()
+export class OrderSummaryController {
+
+    private static logger = createLogger("OrderSummaryController");
+
+    private service: OrderSummaryService;
+    private pageFactory: PageFactory;
+
+    constructor(@Inject() service: OrderSummaryService, @Inject() pageFactory: PageFactory) {
+        this.service = service;
+        this.pageFactory = pageFactory;
+    }
+
+    async readOrder(req: Request, res: Response, next: NextFunction) {
+        const orderId = req.params.orderId;
+        const accessToken = req.orderAdminSession?.getAccessToken() || "";
+        const userId = req.orderAdminSession?.getUserId();
+
+        OrderSummaryController.logger.debug(`Retrieving summary for order [${orderId}] for user [${userId}]...`);
+        const orderSummary = await this.service.fetchOrderSummary(orderId, accessToken);
+
+        let viewModel;
+        if (orderSummary.status === Status.CLIENT_ERROR) {
+            OrderSummaryController.logger.debug(`Client error returned for order [${orderId}] for user [${userId}]`);
+            viewModel = this.pageFactory.buildNotFound();
+        } else if (orderSummary.status === Status.SERVER_ERROR || !orderSummary.summary) {
+            OrderSummaryController.logger.debug(`Server error returned for order [${orderId}] for user [${userId}]`);
+            viewModel = this.pageFactory.buildServiceUnavailable();
+        } else {
+            viewModel = this.pageFactory.buildOrderSummaryPage(orderSummary.summary);
+        }
+
+        return res.render(viewModel.template, {
+            control: viewModel,
+            renderBackButton: BACK_LINK_TOGGLER.orderPageBackLinkEnabled
+        });
+    }
+}

--- a/src/order_summary/OrderSummaryConverter.ts
+++ b/src/order_summary/OrderSummaryConverter.ts
@@ -1,0 +1,68 @@
+import {OrderSummary} from "./OrderSummary";
+import {ItemOptionsDeliveryTimescaleConfigurable} from "@companieshouse/api-sdk-node/dist/services/order/types";
+import {MapperRequest} from "../core/MapperRequest";
+import {CertificateTextMapper} from "../orderdetails/CertificateTextMapper";
+import {Checkout} from "@companieshouse/api-sdk-node/dist/services/order/checkout/types";
+
+export class OrderSummaryConverter {
+
+    private orderSummary: OrderSummary = new OrderSummary();
+
+    mapOrderDetails(checkout: Checkout): void {
+        this.orderSummary.orderReference = checkout.reference;
+        this.mapDeliveryAddress(checkout);
+        this.mapPaymentDetails(checkout);
+        this.orderSummary.backLinkUrl = "javascript:history.back()";
+    }
+
+    mapCertificate(request: MapperRequest): void {
+        this.mapItem(request, "Certificate", this.mapDeliveryMethod(request.item.itemOptions as ItemOptionsDeliveryTimescaleConfigurable));
+        this.orderSummary.hasDeliverableItems = true;
+    }
+
+    mapCertifiedCopy(request: MapperRequest): void {
+        this.mapItem(request, "Certified document", this.mapDeliveryMethod(request.item.itemOptions as ItemOptionsDeliveryTimescaleConfigurable));
+        this.orderSummary.hasDeliverableItems = true;
+    }
+
+    mapMissingImageDelivery(request: MapperRequest): void {
+        this.mapItem(request, "Missing image", "N/A");
+    }
+
+    getOrderSummary(): OrderSummary {
+        return this.orderSummary;
+    }
+
+    private mapItem(request: MapperRequest, itemType: string, deliveryMethod: string): void {
+        this.orderSummary.itemSummary.push({
+            id: request.item.id,
+            orderType: itemType,
+            companyNumber: request.item.companyNumber,
+            deliveryMethod: deliveryMethod,
+            fee: `£${request.item.totalItemCost}`
+        });
+    }
+
+    private mapDeliveryAddress(checkout: Checkout) {
+        this.orderSummary.deliveryDetails = {
+            deliveryAddress: CertificateTextMapper.mapDeliveryDetails(checkout.deliveryDetails)
+        };
+    }
+
+    private mapPaymentDetails(checkout: Checkout) {
+        this.orderSummary.paymentDetails = {
+            paymentReference: checkout.paymentReference || "",
+            amountPaid: `£${checkout.totalOrderCost}`
+        };
+    }
+
+    private mapDeliveryMethod(itemOptions: ItemOptionsDeliveryTimescaleConfigurable): string {
+        if (itemOptions.deliveryTimescale === "standard") {
+            return "Standard";
+        } else if (itemOptions.deliveryTimescale === "same-day") {
+            return "Express";
+        } else {
+            return "";
+        }
+    }
+}

--- a/src/order_summary/OrderSummaryDirector.ts
+++ b/src/order_summary/OrderSummaryDirector.ts
@@ -1,0 +1,33 @@
+import {OrderSummaryConverter} from "./OrderSummaryConverter";
+import {Checkout} from "@companieshouse/api-sdk-node/dist/services/order/checkout/types";
+
+export class OrderSummaryDirector {
+
+    private converter: OrderSummaryConverter;
+
+    constructor(converter: OrderSummaryConverter) {
+        this.converter = converter;
+    }
+
+    mapOrderSummary(checkout: Checkout): void {
+        for (const item of checkout.items) {
+            if (item.kind === "item#certificate") {
+                this.converter.mapCertificate({
+                    orderId: checkout.reference,
+                    item: item
+                });
+            } else if (item.kind === "item#certified-copy") {
+                this.converter.mapCertifiedCopy({
+                    orderId: checkout.reference,
+                    item: item
+                });
+            } else if (item.kind === "item#missing-image-delivery") {
+                this.converter.mapMissingImageDelivery({
+                    orderId: checkout.reference,
+                    item: item
+                });
+            }
+        }
+        this.converter.mapOrderDetails(checkout);
+    }
+}

--- a/src/order_summary/OrderSummaryPage.ts
+++ b/src/order_summary/OrderSummaryPage.ts
@@ -1,0 +1,63 @@
+import {AbstractViewComponent} from "../core/AbstractViewComponent";
+import {ViewModel} from "../core/ViewModel";
+import {ItemSummary, OrderSummary} from "./OrderSummary";
+
+export class OrderSummaryPage extends AbstractViewComponent {
+    constructor(private title: string) {
+        super("page", []);
+    }
+
+    render(): ViewModel {
+        const model = super.render();
+        model.data.title = this.title;
+        return model;
+    }
+}
+
+export class OrderSummaryDetailsComponent extends AbstractViewComponent {
+    constructor(private orderSummary: OrderSummary) {
+        super("orderSummary/order_summary.njk", []);
+    }
+
+    render(): ViewModel {
+        const result = super.render();
+        result.data = this.orderSummary;
+        return result;
+    }
+}
+
+export class ItemDetailsComponent extends AbstractViewComponent {
+    constructor(private itemSummary: ItemSummary) {
+        super("orderSummary/item_details.njk", []);
+    }
+
+    render(): ViewModel {
+        const result = super.render();
+        result.data = this.itemSummary;
+        return result;
+    }
+}
+
+export class DeliveryDetailsComponent extends AbstractViewComponent {
+    constructor(private orderSummary: OrderSummary) {
+        super("orderSummary/delivery_details.njk", []);
+    }
+
+    render(): ViewModel {
+        const result = super.render();
+        result.data = this.orderSummary.deliveryDetails;
+        return result;
+    }
+}
+
+export class PaymentDetailsComponent extends AbstractViewComponent {
+    constructor(private orderSummary: OrderSummary) {
+        super("orderSummary/payment_details.njk", []);
+    }
+
+    render(): ViewModel {
+        const result = super.render();
+        result.data = this.orderSummary.paymentDetails;
+        return result;
+    }
+}

--- a/src/order_summary/OrderSummaryService.ts
+++ b/src/order_summary/OrderSummaryService.ts
@@ -1,0 +1,41 @@
+import {Inject, Service} from "typedi";
+import {OrderSummary} from "./OrderSummary";
+import {OrderSummaryDirector} from "./OrderSummaryDirector";
+import {OrderSummaryConverter} from "./OrderSummaryConverter";
+import {ApiClientFactory} from "../client/ApiClientFactory";
+import {Status} from "../core/Status";
+import "reflect-metadata";
+
+export interface OrderSummaryFetchable {
+    fetchOrderSummary(orderId: string, token: string): Promise<OrderSummaryResult>;
+}
+
+@Service()
+export class OrderSummaryService implements OrderSummaryFetchable {
+
+    constructor(@Inject((process.env.ADMIN_ORDERS_DEVELOPMENT_MODE === "true" ? "stub.client" : "default.client")) public apiClientFactory: ApiClientFactory) {
+    }
+
+    async fetchOrderSummary(orderId: string, token: string): Promise<OrderSummaryResult> {
+        const apiClient = this.apiClientFactory.newApiClient(token);
+        const checkout = await apiClient.checkout.getCheckout(orderId);
+        if (checkout.isFailure()) {
+            if (checkout.value.httpStatusCode == 404 && checkout.value?.errors) {
+                return new OrderSummaryResult(Status.CLIENT_ERROR);
+            } else {
+                return new OrderSummaryResult(Status.SERVER_ERROR);
+            }
+        } else {
+            const converter = new OrderSummaryConverter();
+            const mapper = new OrderSummaryDirector(converter);
+            mapper.mapOrderSummary(checkout.value.resource!);
+            return new OrderSummaryResult(Status.SUCCESS, converter.getOrderSummary());
+        }
+    }
+}
+
+export class OrderSummaryResult {
+
+    constructor(public status: Status, public summary?: OrderSummary) {
+    }
+}

--- a/src/order_summary/PageFactory.ts
+++ b/src/order_summary/PageFactory.ts
@@ -1,0 +1,43 @@
+import "reflect-metadata";
+import {Service} from "typedi";
+import {ErrorPageBuildable} from "../core/ErrorPageBuildable";
+import {GlobalPageFactory} from "../core/GlobalPageFactory";
+import {ViewModel} from "../core/ViewModel";
+import {
+    DeliveryDetailsComponent,
+    ItemDetailsComponent,
+    OrderSummaryDetailsComponent,
+    OrderSummaryPage, PaymentDetailsComponent
+} from "./OrderSummaryPage";
+import {OrderSummary} from "./OrderSummary";
+
+@Service()
+export class PageFactory implements ErrorPageBuildable {
+
+    private static readonly PAGE_TITLE = "Order Details";
+
+    constructor(private globalPageFactory: GlobalPageFactory) {
+    }
+
+    buildOrderSummaryPage(orderSummary: OrderSummary): ViewModel {
+        const pageModel = new OrderSummaryPage(PageFactory.PAGE_TITLE);
+        const content = new OrderSummaryDetailsComponent(orderSummary);
+        pageModel.add(content);
+        orderSummary.itemSummary.forEach(summary => content.add(new ItemDetailsComponent(summary)));
+        pageModel.add(new DeliveryDetailsComponent(orderSummary));
+        pageModel.add(new PaymentDetailsComponent(orderSummary));
+        return pageModel.render();
+    }
+
+    buildNotFound(): ViewModel {
+        return this.globalPageFactory.buildNotFound();
+    }
+
+    buildServiceUnavailable(): ViewModel {
+        return this.globalPageFactory.buildServiceUnavailable();
+    }
+
+    buildUnauthorised(): ViewModel {
+        return this.globalPageFactory.buildUnauthorised();
+    }
+}

--- a/src/order_summary/PageFactory.ts
+++ b/src/order_summary/PageFactory.ts
@@ -24,7 +24,9 @@ export class PageFactory implements ErrorPageBuildable {
         const content = new OrderSummaryDetailsComponent(orderSummary);
         pageModel.add(content);
         orderSummary.itemSummary.forEach(summary => content.add(new ItemDetailsComponent(summary)));
-        pageModel.add(new DeliveryDetailsComponent(orderSummary));
+        if (orderSummary.hasDeliverableItems) {
+            pageModel.add(new DeliveryDetailsComponent(orderSummary));
+        }
         pageModel.add(new PaymentDetailsComponent(orderSummary));
         return pageModel.render();
     }

--- a/src/orderdetails/CertificateTextMapper.ts
+++ b/src/orderdetails/CertificateTextMapper.ts
@@ -231,7 +231,7 @@ export abstract class CertificateTextMapper {
         } else if (companyStatus === CompanyStatus.ADMINISTRATION) {
             delete details.statementOfGoodStanding;
             delete details.liquidators;
-        } 
+        }
         return details;
     }
 }

--- a/src/orderdetails/OrderDetailsController.ts
+++ b/src/orderdetails/OrderDetailsController.ts
@@ -7,6 +7,7 @@ import { OrderDetailsService } from "./OrderDetailsService";
 import { OrderDetailsParameters } from "./OrderDetailsParameters";
 import { Status } from "core/Status";
 import { BACK_LINK_TOGGLER } from "../config/BackLinkToggler";
+import {FEATURE_FLAGS} from "../config/FeatureOptions";
 
 @Service()
 export class OrderDetailsController {
@@ -19,6 +20,10 @@ export class OrderDetailsController {
 
     public async handleGet(req: Request, res: Response, next: NextFunction): Promise<void> {
         OrderDetailsController.logger.trace("GET request received");
+        if (FEATURE_FLAGS.multiItemBasketEnabled) {
+            OrderDetailsController.logger.info("Multi-item basket enabled; redirecting to order summary endpoint...");
+            return res.redirect(`/orders-admin/order-summaries/${req.params.orderId}`);
+        }
         const orderParameters = new OrderDetailsParameters(req.params.orderId, req.orderAdminSession?.getAccessToken() || "");
         const order = await this.service.fetchOrder(orderParameters);
         if (order.status === Status.CLIENT_ERROR) {

--- a/src/search/SearchResultsMapper.ts
+++ b/src/search/SearchResultsMapper.ts
@@ -56,7 +56,7 @@ export class SearchResultsMapper {
 
     private mapLink(summary: CheckoutSummaryResource): string {
         if (FEATURE_FLAGS.multiItemBasketEnabled) {
-            return "javascript:void(0)";
+            return `/orders-admin/order-summaries/${summary.id}`;
         } else if (summary.productLine === "item#certificate" && summary.paymentStatus === "paid") {
             return `/orders-admin/orders/${summary.id}`;
         } else {

--- a/src/views/orderSummary/delivery_details.njk
+++ b/src/views/orderSummary/delivery_details.njk
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m">
+            Delivery details
+        </h2>
+        <dl class="govuk-summary-list" id="deliveryDetailsList">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Delivery address
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    {{ control.data.deliveryAddress | striptags(true) | escape | nl2br }}
+                </dd>
+            </div>
+        </dl>
+    </div>
+</div>

--- a/src/views/orderSummary/item_details.njk
+++ b/src/views/orderSummary/item_details.njk
@@ -1,0 +1,9 @@
+<tr class="govuk-table__row">
+    <td class="govuk-table__cell">
+        <a class="govuk-link" href="javascript:void(0)">{{ control.data.id }}</a>
+    </td>
+    <td class="govuk-table__cell">{{ control.data.orderType }}</td>
+    <td class="govuk-table__cell">{{ control.data.companyNumber }}</td>
+    <td class="govuk-table__cell">{{ control.data.deliveryMethod }}</td>
+    <td class="govuk-table__cell">{{ control.data.fee }}</td>
+</tr>

--- a/src/views/orderSummary/order_summary.njk
+++ b/src/views/orderSummary/order_summary.njk
@@ -1,0 +1,22 @@
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <h1 id="order-reference" class="govuk-heading-xl">{{ control.data.orderReference }}</h1>
+        <h2 class="govuk-heading-m">Order details</h2>
+        <table class="govuk-table">
+            <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Item number</th>
+                <th scope="col" class="govuk-table__header">Order type</th>
+                <th scope="col" class="govuk-table__header">Company number</th>
+                <th scope="col" class="govuk-table__header">Delivery method</th>
+                <th scope="col" class="govuk-table__header">Fee</th>
+            </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+                {% for control in control.controls %}
+                    {% include control.template %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/src/views/orderSummary/payment_details.njk
+++ b/src/views/orderSummary/payment_details.njk
@@ -1,0 +1,26 @@
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m">
+            Payment details
+        </h2>
+        <dl class="govuk-summary-list" id="paymentDetailsList">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Payment reference
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    {{ control.data.paymentReference }}
+                </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Fee
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    {{ control.data.amountPaid }}
+                </dd>
+            </div>
+        </dl>
+    </div>
+</div>

--- a/test/__stub__/checkout_with_all_item_combos.json
+++ b/test/__stub__/checkout_with_all_item_combos.json
@@ -19,7 +19,7 @@
       "description": "missing image delivery for company 00000000",
       "description_identifier": "missing-image-delivery",
       "description_values": {
-        "company_number": "00000000",
+        "company_number": "12345678",
         "missing-image-delivery": "missing image delivery for company 00000000"
       },
       "item_costs": [
@@ -63,7 +63,7 @@
       "description_identifier": "certificate",
       "description_values": {
         "certificate": "certificate for company 00000000",
-        "company_number": "00000000"
+        "company_number": "12345678"
       },
       "item_costs": [
         {

--- a/test/__stub__/checkout_with_no_deliverable_items.json
+++ b/test/__stub__/checkout_with_no_deliverable_items.json
@@ -1,0 +1,71 @@
+{
+  "payment_reference": "payment_reference",
+  "etag": "F00DFACE",
+  "delivery_details": {
+    "country": "Country",
+    "forename": "Forename",
+    "locality": "Locality",
+    "postal_code": "Postcode",
+    "region": "Region",
+    "surname": "Surname",
+    "address_line_1": "Address line 1",
+    "address_line_2": "Address line 2"
+  },
+  "items": [
+    {
+      "id": "MID-123123-123123",
+      "company_name": "The Company",
+      "company_number": "12345678",
+      "description": "missing image delivery for company 00000000",
+      "description_identifier": "missing-image-delivery",
+      "description_values": {
+        "company_number": "12345678",
+        "missing-image-delivery": "missing image delivery for company 12345678"
+      },
+      "item_costs": [
+        {
+          "discountApplied": "0",
+          "itemCost": "3",
+          "calculatedCost": "3",
+          "productType": "missing-image-delivery"
+        }
+      ],
+      "itemOptions": {
+        "filingHistoryBarcode": "barcode",
+        "filingHistoryCategory": "category",
+        "filingHistoryCost": "cost",
+        "filingHistoryDate": "2015-05-26",
+        "filingHistoryDescription": "appoint-person-director-company-with-name",
+        "filingHistoryDescriptionValues": {
+          "officer_name": "Mr Richard John Harris"
+        },
+        "filingHistoryId": "MzEyMzcyNDc2OWFkaXF6a2N4",
+        "filingHistoryType": "AP01"
+      },
+      "etag": "7ae7d006fab4a6bab9fafcfea1eef1b78ffa4e52",
+      "kind": "item#missing-image-delivery",
+      "links": {
+        "self": "/orderable/missing-image-deliveries/MID-123123-123123"
+      },
+      "quantity": 1,
+      "itemUri": "/orderable/missing-image-deliveries/MID-123123-123123",
+      "status": "unknown",
+      "postageCost": "0",
+      "totalItemCost": "3",
+      "postalDelivery": false
+    }
+  ],
+  "kind": "order",
+  "total_order_cost": "3",
+  "reference": "ORD-123123-123123",
+  "paid_at": "2022-05-02T12:00:00.000",
+  "checked_out_by": {
+    "email": "demo@ch.gov.uk",
+    "id": "F00DFACE"
+  },
+  "status": "paid",
+  "links": {
+    "self": "/basket/checkouts/ORD-123123-123123",
+    "payment": "/basket/checkouts/ORD-123123-123123/payment"
+  }
+}

--- a/test/order_summary/OrderSummaryController.test.ts
+++ b/test/order_summary/OrderSummaryController.test.ts
@@ -1,0 +1,142 @@
+import {OrderSummaryController} from "../../src/order_summary/OrderSummaryController";
+import {OrderSummaryResult} from "../../src/order_summary/OrderSummaryService";
+import {Status} from "../../src/core/Status";
+import {PageFactory} from "../../src/order_summary/PageFactory";
+import {OrderSummary} from "../../src/order_summary/OrderSummary";
+import {ViewModel} from "../../src/core/ViewModel";
+import { Request, Response } from "express";
+import "../../src/session/OrderAdminSession";
+import {SessionModel} from "../../src/session/SessionModel";
+import {OrderSummaryService} from "../../src/order_summary/OrderSummaryService";
+
+describe("OrderSummaryController", () => {
+    describe("readOrder", () => {
+        it("Renders order information if resource found", async () => {
+            // given
+            const expectedSummary = {
+                itemSummary: [],
+                hasDeliverableItems: false
+            } as OrderSummary;
+            const expectedOrderSummary = {
+                status: Status.SUCCESS,
+                summary: expectedSummary
+            } as OrderSummaryResult;
+            const mockService = {} as OrderSummaryService;
+            mockService.fetchOrderSummary = jest.fn((orderId: string, token: string): Promise<OrderSummaryResult> => Promise.resolve(expectedOrderSummary));
+            const expectedViewModel = {
+                template: "template"
+            } as ViewModel;
+            const mockPageFactory = {} as PageFactory;
+            mockPageFactory.buildOrderSummaryPage = jest.fn((summary: OrderSummary): ViewModel => expectedViewModel);
+
+            const mockRequest = {} as Request;
+            const orderAdminSession = {} as SessionModel;
+            mockRequest.orderAdminSession = orderAdminSession;
+            mockRequest.params = {
+                orderId: "ORD-123123-123123"
+            };
+            orderAdminSession.getAccessToken = jest.fn((): string => "access_token");
+            orderAdminSession.getUserId = jest.fn((): string => "user_id");
+
+            const mockResponse = {} as Response;
+            mockResponse.render = jest.fn(() => {});
+
+            const mockNextFunction = jest.fn(() => {});
+
+            const controller = new OrderSummaryController(mockService, mockPageFactory);
+
+            // when
+            await controller.readOrder(mockRequest, mockResponse, mockNextFunction);
+
+            // then
+            expect(mockService.fetchOrderSummary).toHaveBeenCalledWith("ORD-123123-123123", "access_token");
+            expect(mockPageFactory.buildOrderSummaryPage).toHaveBeenCalledWith(expectedSummary);
+            expect(mockResponse.render).toHaveBeenCalledWith("template", {
+                control: expectedViewModel,
+                renderBackButton: true
+            });
+        });
+
+        it("Renders not found if resource not found", async () => {
+            // given
+            const expectedOrderSummary = {
+                status: Status.CLIENT_ERROR
+            } as OrderSummaryResult;
+            const mockService = {} as OrderSummaryService;
+            mockService.fetchOrderSummary = jest.fn((orderId: string, token: string): Promise<OrderSummaryResult> => Promise.resolve(expectedOrderSummary));
+            const expectedViewModel = {
+                template: "template"
+            } as ViewModel;
+            const mockPageFactory = {} as PageFactory;
+            mockPageFactory.buildNotFound = jest.fn((): ViewModel => expectedViewModel);
+
+            const mockRequest = {} as Request;
+            const orderAdminSession = {} as SessionModel;
+            mockRequest.orderAdminSession = orderAdminSession;
+            mockRequest.params = {
+                orderId: "ORD-123123-123123"
+            };
+            orderAdminSession.getAccessToken = jest.fn((): string => "access_token");
+            orderAdminSession.getUserId = jest.fn((): string => "user_id");
+
+            const mockResponse = {} as Response;
+            mockResponse.render = jest.fn(() => {});
+
+            const mockNextFunction = jest.fn(() => {});
+
+            const controller = new OrderSummaryController(mockService, mockPageFactory);
+
+            // when
+            await controller.readOrder(mockRequest, mockResponse, mockNextFunction);
+
+            // then
+            expect(mockService.fetchOrderSummary).toHaveBeenCalledWith("ORD-123123-123123", "access_token");
+            expect(mockPageFactory.buildNotFound).toHaveBeenCalled();
+            expect(mockResponse.render).toHaveBeenCalledWith("template", {
+                control: expectedViewModel,
+                renderBackButton: true
+            });
+        });
+
+        it("Renders service unavailable if server error occurs", async () => {
+            // given
+            const expectedOrderSummary = {
+                status: Status.SERVER_ERROR
+            } as OrderSummaryResult;
+            const mockService = {} as OrderSummaryService;
+            mockService.fetchOrderSummary = jest.fn((orderId: string, token: string): Promise<OrderSummaryResult> => Promise.resolve(expectedOrderSummary));
+            const expectedViewModel = {
+                template: "template"
+            } as ViewModel;
+            const mockPageFactory = {} as PageFactory;
+            mockPageFactory.buildServiceUnavailable = jest.fn((): ViewModel => expectedViewModel);
+
+            const mockRequest = {} as Request;
+            const orderAdminSession = {} as SessionModel;
+            mockRequest.orderAdminSession = orderAdminSession;
+            mockRequest.params = {
+                orderId: "ORD-123123-123123"
+            };
+            orderAdminSession.getAccessToken = jest.fn((): string => "access_token");
+            orderAdminSession.getUserId = jest.fn((): string => "user_id");
+
+            const mockResponse = {} as Response;
+            mockResponse.render = jest.fn(() => {});
+
+            const mockNextFunction = jest.fn(() => {});
+
+            const controller = new OrderSummaryController(mockService, mockPageFactory);
+
+            // when
+            await controller.readOrder(mockRequest, mockResponse, mockNextFunction);
+
+            // then
+            expect(mockService.fetchOrderSummary).toHaveBeenCalledWith("ORD-123123-123123", "access_token");
+            expect(mockPageFactory.buildServiceUnavailable).toHaveBeenCalled();
+            expect(mockResponse.render).toHaveBeenCalledWith("template", {
+                control: expectedViewModel,
+                renderBackButton: true
+            });
+        });
+    });
+});

--- a/test/order_summary/OrderSummaryService.unit.test.ts
+++ b/test/order_summary/OrderSummaryService.unit.test.ts
@@ -1,0 +1,105 @@
+import {OrderSummaryResult, OrderSummaryService} from "../../src/order_summary/OrderSummaryService";
+import { expect } from "chai";
+import { OrderSummary } from "../../src/order_summary/OrderSummary";
+import {StubApiClientFactory} from "../../src/client/StubApiClientFactory";
+import checkoutResource from "../__stub__/checkout_with_all_item_combos.json";
+import checkoutNoDeliverables from "../__stub__/checkout_with_no_deliverable_items.json";
+import {Status} from "../../src/core/Status";
+
+describe("OrderSummaryService", () => {
+    describe("fetchOrderSummary", () => {
+        it("Returns a mapped order summary object", async () => {
+            // given
+            const apiClientFactory = new StubApiClientFactory();
+            apiClientFactory.willReturnSuccessfulCheckoutResponse(checkoutResource);
+            const service = new OrderSummaryService(apiClientFactory);
+
+            // when
+            const actual = await service.fetchOrderSummary("ORD-123123-123123", "F00DFACE");
+
+            // then
+            expect(actual).to.deep.equal(new OrderSummaryResult(Status.SUCCESS, {
+                backLinkUrl: "javascript:history.back()",
+                orderReference: "ORD-123123-123123",
+                deliveryDetails: {
+                    deliveryAddress: "Forename Surname\nAddress line 1\nAddress line 2\nLocality\nRegion\nPostcode\nCountry\n"
+                },
+                paymentDetails: {
+                    paymentReference: "payment_reference",
+                    amountPaid: "£133"
+                },
+                hasDeliverableItems: true,
+                itemSummary: [
+                    {
+                        id: "MID-123123-123123",
+                        orderType: "Missing image",
+                        companyNumber: "12345678",
+                        deliveryMethod: "N/A",
+                        fee: "£3"
+                    },
+                    {
+                        id: "CRT-123123-123123",
+                        orderType: "Certificate",
+                        companyNumber: "12345678",
+                        deliveryMethod: "Standard",
+                        fee: "£15"
+                    },
+                    {
+                        id: "CRT-123123-123124",
+                        orderType: "Certificate",
+                        companyNumber: "12345679",
+                        deliveryMethod: "Express",
+                        fee: "£50"
+                    },
+                    {
+                        id: "CCD-123123-123123",
+                        orderType: "Certified document",
+                        companyNumber: "12345678",
+                        deliveryMethod: "Standard",
+                        fee: "£15"
+                    },
+                    {
+                        id: "CCD-123123-123124",
+                        orderType: "Certified document",
+                        companyNumber: "12345670",
+                        deliveryMethod: "Express",
+                        fee: "£50"
+                    }
+                ]
+            } as OrderSummary));
+        });
+
+        it("Hides delivery details if no deliverable items ordered", async () => {
+            // given
+            const apiClientFactory = new StubApiClientFactory();
+            apiClientFactory.willReturnSuccessfulCheckoutResponse(checkoutNoDeliverables);
+            const service = new OrderSummaryService(apiClientFactory);
+
+            // when
+            const actual = await service.fetchOrderSummary("ORD-123123-123123", "F00DFACE");
+
+            // then
+            expect(actual).to.deep.equal(new OrderSummaryResult(Status.SUCCESS, {
+                backLinkUrl: "javascript:history.back()",
+                orderReference: "ORD-123123-123123",
+                deliveryDetails: {
+                    deliveryAddress: "Forename Surname\nAddress line 1\nAddress line 2\nLocality\nRegion\nPostcode\nCountry\n"
+                },
+                paymentDetails: {
+                    paymentReference: "payment_reference",
+                    amountPaid: "£3"
+                },
+                hasDeliverableItems: false,
+                itemSummary: [
+                    {
+                        id: "MID-123123-123123",
+                        orderType: "Missing image",
+                        companyNumber: "12345678",
+                        deliveryMethod: "N/A",
+                        fee: "£3"
+                    }
+                ]
+            } as OrderSummary));
+        });
+    });
+});

--- a/test/order_summary/PageFactory.test.ts
+++ b/test/order_summary/PageFactory.test.ts
@@ -1,0 +1,114 @@
+import {PageFactory} from "../../src/order_summary/PageFactory";
+import {GlobalPageFactory} from "../../src/core/GlobalPageFactory";
+import {OrderSummary} from "../../src/order_summary/OrderSummary";
+
+describe("PageFactory", () => {
+    describe("buildOrderSummaryPage", () => {
+        it("Constructs a view model for an order with deliverable items", () => {
+            // given
+            const pageFactory = new PageFactory(new GlobalPageFactory());
+            const orderSummary: OrderSummary = {
+                orderReference: "ORD-123123-123123",
+                itemSummary: [{
+                    id: "CRT-123123-123123"
+                }],
+                hasDeliverableItems: true,
+                deliveryDetails: {
+                    deliveryAddress: "address"
+                },
+                paymentDetails: {
+                    paymentReference: "payment_reference",
+                    amountPaid: "£15"
+                }
+            };
+
+            // when
+            const actual = pageFactory.buildOrderSummaryPage(orderSummary);
+
+            // then
+            expect(actual).toEqual({
+                template: "page",
+                controls: [
+                    {
+                        template: "orderSummary/order_summary.njk",
+                        controls: [{
+                            template: "orderSummary/item_details.njk",
+                            controls: [],
+                            data: {
+                                id: "CRT-123123-123123"
+                            }
+                        }],
+                        data: orderSummary
+                    },
+                    {
+                        template: "orderSummary/delivery_details.njk",
+                        controls: [],
+                        data: {
+                            deliveryAddress: "address"
+                        }
+                    },
+                    {
+                        template: "orderSummary/payment_details.njk",
+                        controls: [],
+                        data: {
+                            paymentReference: "payment_reference",
+                            amountPaid: "£15"
+                        }
+                    }],
+                data: {
+                    title: "Order Details"
+                }
+            });
+        });
+
+        it("Constructs a view model for an order with no deliverable items", () => {
+            // given
+            const pageFactory = new PageFactory(new GlobalPageFactory());
+            const orderSummary: OrderSummary = {
+                orderReference: "ORD-123123-123123",
+                itemSummary: [{
+                    id: "CRT-123123-123123"
+                }],
+                hasDeliverableItems: false,
+                deliveryDetails: {
+                    deliveryAddress: "address"
+                },
+                paymentDetails: {
+                    paymentReference: "payment_reference",
+                    amountPaid: "£15"
+                }
+            };
+
+            // when
+            const actual = pageFactory.buildOrderSummaryPage(orderSummary);
+
+            // then
+            expect(actual).toEqual({
+                template: "page",
+                controls: [
+                    {
+                        template: "orderSummary/order_summary.njk",
+                        controls: [{
+                            template: "orderSummary/item_details.njk",
+                            controls: [],
+                            data: {
+                                id: "CRT-123123-123123"
+                            }
+                        }],
+                        data: orderSummary
+                    },
+                    {
+                        template: "orderSummary/payment_details.njk",
+                        controls: [],
+                        data: {
+                            paymentReference: "payment_reference",
+                            amountPaid: "£15"
+                        }
+                    }],
+                data: {
+                    title: "Order Details"
+                }
+            });
+        });
+    });
+});

--- a/test/search/SearchResultsMapper.test.ts
+++ b/test/search/SearchResultsMapper.test.ts
@@ -203,7 +203,7 @@ describe("SearchResultsMapper", () => {
                     },
                     orderDate: "01/01/2022",
                     paymentStatus: "Paid",
-                    detailHref: "javascript:void(0)"
+                    detailHref: "/orders-admin/order-summaries/ORD-123123-123123"
                 },
                 {
                     id: "ORD-321321-321321",
@@ -212,7 +212,7 @@ describe("SearchResultsMapper", () => {
                     },
                     orderDate: "05/05/2021",
                     paymentStatus: "Paid",
-                    detailHref: "javascript:void(0)"
+                    detailHref: "/orders-admin/order-summaries/ORD-321321-321321"
                 },
                 {
                     id: "ORD-121212-121212",
@@ -221,7 +221,7 @@ describe("SearchResultsMapper", () => {
                     },
                     orderDate: "12/02/2020",
                     paymentStatus: "Unknown",
-                    detailHref: "javascript:void(0)"
+                    detailHref: "/orders-admin/order-summaries/ORD-121212-121212"
                 },
                 {
                     id: "ORD-323232-323232",
@@ -230,7 +230,7 @@ describe("SearchResultsMapper", () => {
                     },
                     orderDate: "21/12/2021",
                     paymentStatus: "Paid",
-                    detailHref: "javascript:void(0)"
+                    detailHref: "/orders-admin/order-summaries/ORD-323232-323232"
                 },
                 {
                     id: "ORD-230230-230230",
@@ -239,7 +239,7 @@ describe("SearchResultsMapper", () => {
                     },
                     orderDate: "Unknown",
                     paymentStatus: "Unknown",
-                    detailHref: "javascript:void(0)"
+                    detailHref: "/orders-admin/order-summaries/ORD-230230-230230"
                 }
             ] as OrderSummary[]
         } as SearchResults);


### PR DESCRIPTION
* Order summary page summarises items, delivery details and payment
  details of an order.
* Delivery details section not rendered if order contains no deliverable
  items.
* View order details endpoint redirects user agent to order-summaries
  endpoint if feature flag ORDERS_SEARCH_MULTIBASKET_ENABLED is true.

Resolves:
[GCI-2182](https://companieshouse.atlassian.net/browse/GCI-2182)