### PR TITLE
GCI-2315 Implement certificate item summary mappers

### DIFF
--- a/src/core/Page.ts
+++ b/src/core/Page.ts
@@ -1,7 +1,7 @@
-import {AbstractViewComponent} from "../core/AbstractViewComponent";
-import {ViewModel} from "../core/ViewModel";
+import {AbstractViewComponent} from "./AbstractViewComponent";
+import {ViewModel} from "./ViewModel";
 
-export class MissingImageItemSummaryPage extends AbstractViewComponent {
+export class Page extends AbstractViewComponent {
 
     constructor(private title: string) {
         super("page", []);

--- a/src/orderitemsummary/AbstractCertificateMapper.ts
+++ b/src/orderitemsummary/AbstractCertificateMapper.ts
@@ -1,0 +1,53 @@
+import { OrderItemMapper } from "./OrderItemMapper";
+import { CertificateItemSummaryView } from "./CertificateItemSummaryView";
+import { MapperRequest } from "../mappers/MapperRequest";
+import { ItemOptions as CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/certificates";
+import {ViewModel} from "../core/ViewModel";
+import {Page} from "../core/Page";
+import {CertificateDetailsComponent} from "./CertificateDetailsComponent";
+import {CertificateTextMapper} from "../orderdetails/CertificateTextMapper";
+
+export abstract class AbstractCertificateMapper implements OrderItemMapper {
+    protected readonly data: CertificateItemSummaryView
+
+    constructor (protected mapperRequest: MapperRequest) {
+        this.data = new CertificateItemSummaryView();
+    }
+
+    map (): void {
+        this.data.orderId = this.mapperRequest.orderId;
+        this.data.itemId = this.mapperRequest.item.id;
+        this.mapCompanyDetails();
+        this.mapCertificateDetails();
+        this.mapDeliveryDetails();
+        this.mapFee();
+        this.data.backLinkUrl = "javascript:history.back()";
+    }
+
+    getMappedOrder (): ViewModel {
+        const page = new Page(`Summary of item ${this.data.itemId} in order ${this.data.orderId}`);
+        page.add(new CertificateDetailsComponent(this.data));
+        return page.render();
+    }
+
+    protected abstract mapCertificateDetails(): void;
+
+    protected addField(key: string, value: string): void {
+        this.data.itemDetails.push({key, value});
+    }
+
+    private mapCompanyDetails(): void {
+        this.addField("Company name", this.mapperRequest.item.companyName);
+        this.addField("Company number", this.mapperRequest.item.companyNumber);
+    }
+
+    private mapDeliveryDetails(): void {
+        const itemOptions = this.mapperRequest.item.itemOptions as CertificateItemOptions;
+        this.addField("Delivery method", CertificateTextMapper.mapDeliveryMethod(itemOptions) || "");
+        this.addField("Email copy required", CertificateTextMapper.mapEmailCopyRequired(itemOptions));
+    }
+
+    private mapFee(): void {
+        this.addField("Fee", `£${this.mapperRequest.item.totalItemCost}`);
+    }
+}

--- a/src/orderitemsummary/CertificateDetailsComponent.ts
+++ b/src/orderitemsummary/CertificateDetailsComponent.ts
@@ -1,0 +1,15 @@
+import {AbstractViewComponent} from "../core/AbstractViewComponent";
+import {ViewModel} from "../core/ViewModel";
+import {CertificateItemSummaryView} from "./CertificateItemSummaryView";
+
+export class CertificateDetailsComponent extends AbstractViewComponent {
+    constructor(private summary: CertificateItemSummaryView) {
+        super("orderItemSummary/order_item_summary_certificate.njk", []);
+    }
+
+    render(): ViewModel {
+        const result = super.render();
+        result.data = this.summary;
+        return result;
+    }
+}

--- a/src/orderitemsummary/CertificateItemSummaryView.ts
+++ b/src/orderitemsummary/CertificateItemSummaryView.ts
@@ -1,0 +1,6 @@
+export class CertificateItemSummaryView {
+    orderId?: string;
+    itemId?: string;
+    itemDetails: {key: string, value: string}[] = [];
+    backLinkUrl?: string;
+}

--- a/src/orderitemsummary/CompanyType.ts
+++ b/src/orderitemsummary/CompanyType.ts
@@ -1,0 +1,4 @@
+export const enum CompanyType {
+    LIMITED_LIABILITY_PARTNERSHIP = "llp",
+    LIMITED_PARTNERSHIP = "limited-partnership"
+}

--- a/src/orderitemsummary/GovUkOrderItemSummaryView.ts
+++ b/src/orderitemsummary/GovUkOrderItemSummaryView.ts
@@ -1,8 +1,0 @@
-import { GovUkSummaryList } from "../govuk/GovUkSummaryList";
-
-export class GovUkOrderItemSummaryView {
-    orderId?: string;
-    itemId?: string;
-    itemDetails: GovUkSummaryList = new GovUkSummaryList();
-    backLinkUrl?: string;
-}

--- a/src/orderitemsummary/LLPCertificateMapper.ts
+++ b/src/orderitemsummary/LLPCertificateMapper.ts
@@ -1,0 +1,32 @@
+import { AbstractCertificateMapper } from "./AbstractCertificateMapper";
+import { ItemOptions as CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
+import { MapUtil } from "../service/MapUtil";
+import { CompanyStatus } from "../model/CompanyStatus";
+import { MapperRequest } from "../mappers/MapperRequest";
+
+export class LLPCertificateMapper extends AbstractCertificateMapper {
+
+    constructor (mapperRequest: MapperRequest) {
+        super(mapperRequest);
+    }
+
+    protected mapCertificateDetails (): void {
+        const itemOptions = this.mapperRequest.item.itemOptions as CertificateItemOptions;
+        this.addText("Certificate type", MapUtil.mapCertificateType(itemOptions.certificateType) || "");
+        if (itemOptions.certificateType === "dissolution") {
+            return;
+        }
+        if (itemOptions.companyStatus === CompanyStatus.ACTIVE) {
+            this.addText("Statement of good standing", MapUtil.determineItemOptionsSelectedText(itemOptions.includeGoodStandingInformation));
+        }
+        this.addText("Registered office address", MapUtil.mapAddressOptions(itemOptions.registeredOfficeAddressDetails));
+        this.addHtml("The names of all current designated members", MapUtil.mapMembersOptions("Including designated members':", itemOptions.designatedMemberDetails));
+        this.addHtml("The names of all current members", MapUtil.mapMembersOptions("Including members':", itemOptions.memberDetails));
+        if (itemOptions.companyStatus === CompanyStatus.ADMINISTRATION) {
+            this.addText("Administrators' details", MapUtil.determineItemOptionsSelectedText(itemOptions.administratorsDetails?.includeBasicInformation));
+        }
+        if (itemOptions.companyStatus === CompanyStatus.LIQUIDATION) {
+            this.addText("Liquidators' details", MapUtil.determineItemOptionsSelectedText(itemOptions.liquidatorsDetails?.includeBasicInformation));
+        }
+    }
+}

--- a/src/orderitemsummary/LLPCertificateMapper.ts
+++ b/src/orderitemsummary/LLPCertificateMapper.ts
@@ -1,8 +1,8 @@
 import { AbstractCertificateMapper } from "./AbstractCertificateMapper";
 import { ItemOptions as CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
-import { MapUtil } from "../service/MapUtil";
-import { CompanyStatus } from "../model/CompanyStatus";
+import { CompanyStatus } from "../orderdetails/CompanyStatus";
 import { MapperRequest } from "../mappers/MapperRequest";
+import {CertificateTextMapper} from "../orderdetails/CertificateTextMapper";
 
 export class LLPCertificateMapper extends AbstractCertificateMapper {
 
@@ -12,21 +12,21 @@ export class LLPCertificateMapper extends AbstractCertificateMapper {
 
     protected mapCertificateDetails (): void {
         const itemOptions = this.mapperRequest.item.itemOptions as CertificateItemOptions;
-        this.addText("Certificate type", MapUtil.mapCertificateType(itemOptions.certificateType) || "");
+        this.addField("Certificate type", CertificateTextMapper.mapCertificateType(itemOptions.certificateType) || "");
         if (itemOptions.certificateType === "dissolution") {
             return;
         }
         if (itemOptions.companyStatus === CompanyStatus.ACTIVE) {
-            this.addText("Statement of good standing", MapUtil.determineItemOptionsSelectedText(itemOptions.includeGoodStandingInformation));
+            this.addField("Statement of good standing", CertificateTextMapper.isOptionSelected(itemOptions.includeGoodStandingInformation));
         }
-        this.addText("Registered office address", MapUtil.mapAddressOptions(itemOptions.registeredOfficeAddressDetails));
-        this.addHtml("The names of all current designated members", MapUtil.mapMembersOptions("Including designated members':", itemOptions.designatedMemberDetails));
-        this.addHtml("The names of all current members", MapUtil.mapMembersOptions("Including members':", itemOptions.memberDetails));
+        this.addField("Registered office address", CertificateTextMapper.mapAddressOption(itemOptions.registeredOfficeAddressDetails?.includeAddressRecordsType));
+        this.addField("The names of all current designated members", CertificateTextMapper.mapMembersOptions("Including designated members':", itemOptions.designatedMemberDetails));
+        this.addField("The names of all current members", CertificateTextMapper.mapMembersOptions("Including members':", itemOptions.memberDetails));
         if (itemOptions.companyStatus === CompanyStatus.ADMINISTRATION) {
-            this.addText("Administrators' details", MapUtil.determineItemOptionsSelectedText(itemOptions.administratorsDetails?.includeBasicInformation));
+            this.addField("Administrators' details", CertificateTextMapper.isOptionSelected(itemOptions.administratorsDetails?.includeBasicInformation));
         }
         if (itemOptions.companyStatus === CompanyStatus.LIQUIDATION) {
-            this.addText("Liquidators' details", MapUtil.determineItemOptionsSelectedText(itemOptions.liquidatorsDetails?.includeBasicInformation));
+            this.addField("Liquidators' details", CertificateTextMapper.isOptionSelected(itemOptions.liquidatorsDetails?.includeBasicInformation));
         }
     }
 }

--- a/src/orderitemsummary/LPCertificateMapper.ts
+++ b/src/orderitemsummary/LPCertificateMapper.ts
@@ -1,7 +1,7 @@
 import { AbstractCertificateMapper } from "./AbstractCertificateMapper";
 import { MapperRequest } from "../mappers/MapperRequest";
 import { ItemOptions as CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
-import { MapUtil } from "../service/MapUtil";
+import {CertificateTextMapper} from "../orderdetails/CertificateTextMapper";
 
 export class LPCertificateMapper extends AbstractCertificateMapper {
 
@@ -11,11 +11,11 @@ export class LPCertificateMapper extends AbstractCertificateMapper {
 
     protected mapCertificateDetails (): void {
         const itemOptions = this.mapperRequest.item.itemOptions as CertificateItemOptions;
-        this.addText("Certificate type", MapUtil.mapCertificateType(itemOptions.certificateType) || "");
-        this.addText("Statement of good standing", MapUtil.determineItemOptionsSelectedText(itemOptions.includeGoodStandingInformation));
-        this.addText("Principal place of business", MapUtil.mapAddressOptions(itemOptions.principalPlaceOfBusinessDetails));
-        this.addText("The names of all current general partners", MapUtil.determineItemOptionsSelectedText(itemOptions.generalPartnerDetails?.includeBasicInformation));
-        this.addText("The names of all current limited partners", MapUtil.determineItemOptionsSelectedText(itemOptions.limitedPartnerDetails?.includeBasicInformation));
-        this.addText("General nature of business", MapUtil.determineItemOptionsSelectedText(itemOptions.includeGeneralNatureOfBusinessInformation));
+        this.addField("Certificate type", CertificateTextMapper.mapCertificateType(itemOptions.certificateType) || "");
+        this.addField("Statement of good standing", CertificateTextMapper.isOptionSelected(itemOptions.includeGoodStandingInformation));
+        this.addField("Principal place of business", CertificateTextMapper.mapAddressOption(itemOptions.principalPlaceOfBusinessDetails?.includeAddressRecordsType));
+        this.addField("The names of all current general partners", CertificateTextMapper.isOptionSelected(itemOptions.generalPartnerDetails?.includeBasicInformation));
+        this.addField("The names of all current limited partners", CertificateTextMapper.isOptionSelected(itemOptions.limitedPartnerDetails?.includeBasicInformation));
+        this.addField("General nature of business", CertificateTextMapper.isOptionSelected(itemOptions.includeGeneralNatureOfBusinessInformation));
     }
 }

--- a/src/orderitemsummary/LPCertificateMapper.ts
+++ b/src/orderitemsummary/LPCertificateMapper.ts
@@ -1,0 +1,21 @@
+import { AbstractCertificateMapper } from "./AbstractCertificateMapper";
+import { MapperRequest } from "../mappers/MapperRequest";
+import { ItemOptions as CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
+import { MapUtil } from "../service/MapUtil";
+
+export class LPCertificateMapper extends AbstractCertificateMapper {
+
+    constructor (mapperRequest: MapperRequest) {
+        super(mapperRequest);
+    }
+
+    protected mapCertificateDetails (): void {
+        const itemOptions = this.mapperRequest.item.itemOptions as CertificateItemOptions;
+        this.addText("Certificate type", MapUtil.mapCertificateType(itemOptions.certificateType) || "");
+        this.addText("Statement of good standing", MapUtil.determineItemOptionsSelectedText(itemOptions.includeGoodStandingInformation));
+        this.addText("Principal place of business", MapUtil.mapAddressOptions(itemOptions.principalPlaceOfBusinessDetails));
+        this.addText("The names of all current general partners", MapUtil.determineItemOptionsSelectedText(itemOptions.generalPartnerDetails?.includeBasicInformation));
+        this.addText("The names of all current limited partners", MapUtil.determineItemOptionsSelectedText(itemOptions.limitedPartnerDetails?.includeBasicInformation));
+        this.addText("General nature of business", MapUtil.determineItemOptionsSelectedText(itemOptions.includeGeneralNatureOfBusinessInformation));
+    }
+}

--- a/src/orderitemsummary/MissingImageDeliveryMapper.ts
+++ b/src/orderitemsummary/MissingImageDeliveryMapper.ts
@@ -1,7 +1,7 @@
 import { OrderItemMapper } from "./OrderItemMapper";
 import { ItemOptions as MissingImageDeliveryItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/mid";
 import { MapperRequest } from "../mappers/MapperRequest";
-import {MissingImageItemSummaryPage} from "./MissingImageItemSummaryPage";
+import {Page} from "../core/Page";
 import {MissingImageDeliverySummary} from "./MissingImageDeliverySummary";
 import {MissingImageDeliveryDetailsComponent} from "./MissingImageDeliveryDetailsComponent";
 import {ViewModel} from "../core/ViewModel";
@@ -22,7 +22,7 @@ export class MissingImageDeliveryMapper implements OrderItemMapper {
     }
 
     getMappedOrder (): ViewModel {
-        const result = new MissingImageItemSummaryPage(`Summary of item ${this.data.itemId} in order ${this.data.orderId}`);
+        const result = new Page(`Summary of item ${this.data.itemId} in order ${this.data.orderId}`);
         result.add(new MissingImageDeliveryDetailsComponent(this.data));
         return result.render();
     }

--- a/src/orderitemsummary/OrderItemSummaryFactory.ts
+++ b/src/orderitemsummary/OrderItemSummaryFactory.ts
@@ -2,13 +2,27 @@ import { OrderItemMapper } from "./OrderItemMapper";
 import { MapperRequest } from "../mappers/MapperRequest";
 import { MissingImageDeliveryMapper } from "./MissingImageDeliveryMapper";
 import { NullOrderItemMapper } from "./NullOrderItemMapper";
+import { ItemOptions as CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/certificates";
 import {Service} from "typedi";
 import "reflect-metadata";
+import { OtherCompanyTypesCertificateMapper } from "./OtherCompanyTypesCertificateMapper";
+import {LPCertificateMapper} from "./LPCertificateMapper";
+import {LLPCertificateMapper} from "./LLPCertificateMapper";
+import {CompanyType} from "./CompanyType";
 
 @Service()
 export class OrderItemSummaryFactory {
     getMapper (mapperRequest: MapperRequest): OrderItemMapper {
-        if (mapperRequest.item.kind === "item#missing-image-delivery") {
+        if (mapperRequest.item.kind === "item#certificate") {
+            const itemOptions = mapperRequest.item.itemOptions as CertificateItemOptions;
+            if (itemOptions.companyType === CompanyType.LIMITED_LIABILITY_PARTNERSHIP) {
+                return new LLPCertificateMapper(mapperRequest);
+            } else if (itemOptions.companyType === CompanyType.LIMITED_PARTNERSHIP) {
+                return new LPCertificateMapper(mapperRequest);
+            } else {
+                return new OtherCompanyTypesCertificateMapper(mapperRequest);
+            }
+        } else if (mapperRequest.item.kind === "item#missing-image-delivery") {
             return new MissingImageDeliveryMapper(mapperRequest);
         } else {
             return new NullOrderItemMapper();

--- a/src/orderitemsummary/OtherCompanyTypesCertificateMapper.ts
+++ b/src/orderitemsummary/OtherCompanyTypesCertificateMapper.ts
@@ -1,0 +1,32 @@
+import { AbstractCertificateMapper } from "./AbstractCertificateMapper";
+import { MapperRequest } from "../mappers/MapperRequest";
+import { ItemOptions as CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/certificates";
+import {CertificateTextMapper} from "../orderdetails/CertificateTextMapper";
+import {CompanyStatus} from "../orderdetails/CompanyStatus";
+
+export class OtherCompanyTypesCertificateMapper extends AbstractCertificateMapper {
+    constructor (mapperRequest: MapperRequest) {
+        super(mapperRequest);
+    }
+
+    mapCertificateDetails (): void {
+        const itemOptions = this.mapperRequest.item.itemOptions as CertificateItemOptions;
+        this.addField("Certificate type", CertificateTextMapper.mapCertificateType(itemOptions.certificateType) || "");
+        if (itemOptions.certificateType === "dissolution") {
+            return;
+        }
+        if (itemOptions.companyStatus === CompanyStatus.ACTIVE) {
+            this.addField("Statement of good standing", CertificateTextMapper.isOptionSelected(itemOptions.includeGoodStandingInformation));
+        }
+        this.addField("Registered office address", CertificateTextMapper.mapAddressOption(itemOptions.registeredOfficeAddressDetails?.includeAddressRecordsType));
+        this.addField("The names of all current company directors", CertificateTextMapper.mapDirectorOptions(itemOptions.directorDetails));
+        this.addField("The names of all current secretaries", CertificateTextMapper.mapSecretaryOptions(itemOptions.secretaryDetails));
+        this.addField("Company objects", CertificateTextMapper.isOptionSelected(itemOptions.includeCompanyObjectsInformation));
+        if (itemOptions.companyStatus === CompanyStatus.ADMINISTRATION) {
+            this.addField("Administrators' details", CertificateTextMapper.isOptionSelected(itemOptions.administratorsDetails?.includeBasicInformation));
+        }
+        if (itemOptions.companyStatus === CompanyStatus.LIQUIDATION) {
+            this.addField("Liquidators' details", CertificateTextMapper.isOptionSelected(itemOptions.liquidatorsDetails?.includeBasicInformation));
+        }
+    }
+}

--- a/test/__mocks__/mocks.ts
+++ b/test/__mocks__/mocks.ts
@@ -1,6 +1,5 @@
 import { Item } from "@companieshouse/api-sdk-node/dist/services/order/order/types";
-import {CertificateItemSummaryView} from "../../src/orderitemsummary/CertificateItemSummaryView";
-import {ItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/certificates";
+import {ItemOptions as CertificateItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/certificates";
 import {ViewModel} from "../../dist/core/ViewModel";
 
 export const ORDER_ID = "ORD-123456-123456";
@@ -104,7 +103,7 @@ export const mockCertificateItem: Item = {
         },
         surname: "surname",
         companyType: "ltd"
-    } as ItemOptions,
+    } as CertificateItemOptions,
     etag: "abcdefg123456",
     kind: "item#certificate",
     links: {
@@ -146,7 +145,7 @@ export const mockDissolvedCertificateItem: Item = {
         registeredOfficeAddressDetails: {},
         secretaryDetails: {},
         surname: "surname"
-    } as ItemOptions,
+    } as CertificateItemOptions,
     etag: "abcdefg123456",
     kind: "item#certificate",
     links: {
@@ -348,7 +347,7 @@ export const mockLiquidatedLtdCertificateItemView: ViewModel = {
     template: "page"
 };
 
-export const mockDissolvedLtdCertificateItemView: ViewModel = {
+export const mockDissolvedCertificateItemView: ViewModel = {
     controls: [{
         controls: [],
         data: {
@@ -366,6 +365,242 @@ export const mockDissolvedLtdCertificateItemView: ViewModel = {
                 {
                     key: "Certificate type",
                     value: "Dissolution with all company name changes"
+                },
+                {
+                    key: "Delivery method",
+                    value: "Standard delivery (aim to dispatch within 10 working days)"
+                },
+                {
+                    key: "Email copy required",
+                    value: "Email only available for express delivery method"
+                },
+                {
+                    key: "Fee",
+                    value: "£15"
+                }
+            ],
+            backLinkUrl: "javascript:history.back()"
+        },
+        template: "orderItemSummary/order_item_summary_certificate.njk"
+    }],
+    data: {
+        title: "Summary of item CRT-123456-123456 in order ORD-123456-123456"
+    },
+    template: "page"
+};
+
+export const mockActiveLLPCertificateItemView: ViewModel = {
+    controls: [{
+        controls: [],
+        data: {
+            orderId: ORDER_ID,
+            itemId: CERTIFICATE_ID,
+            itemDetails: [
+                {
+                    key: "Company name",
+                    value: "Company Name"
+                },
+                {
+                    key: "Company number",
+                    value: "00000000"
+                },
+                {
+                    key: "Certificate type",
+                    value: "Incorporation with all company name changes"
+                },
+                {
+                    key: "Statement of good standing",
+                    value: "Yes"
+                },
+                {
+                    key: "Registered office address",
+                    value: "Current address and the one previous"
+                },
+                {
+                    key: "The names of all current designated members",
+                    value: "Yes"
+                },
+                {
+                    key: "The names of all current members",
+                    value: "Yes"
+                },
+                {
+                    key: "Delivery method",
+                    value: "Standard delivery (aim to dispatch within 10 working days)"
+                },
+                {
+                    key: "Email copy required",
+                    value: "Email only available for express delivery method"
+                },
+                {
+                    key: "Fee",
+                    value: "£15"
+                }
+            ],
+            backLinkUrl: "javascript:history.back()"
+        },
+        template: "orderItemSummary/order_item_summary_certificate.njk"
+    }],
+    data: {
+        title: "Summary of item CRT-123456-123456 in order ORD-123456-123456"
+    },
+    template: "page"
+};
+
+export const mockAdministratedLLPCertificateItemView: ViewModel = {
+    controls: [{
+        controls: [],
+        data: {
+            orderId: ORDER_ID,
+            itemId: CERTIFICATE_ID,
+            itemDetails: [
+                {
+                    key: "Company name",
+                    value: "Company Name"
+                },
+                {
+                    key: "Company number",
+                    value: "00000000"
+                },
+                {
+                    key: "Certificate type",
+                    value: "Incorporation with all company name changes"
+                },
+                {
+                    key: "Registered office address",
+                    value: "Current address and the one previous"
+                },
+                {
+                    key: "The names of all current designated members",
+                    value: "Including designated members':\n\nCorrespondence address\nAppointment date\nCountry of residence\nDate of birth (month and year)\n"
+                },
+                {
+                    key: "The names of all current members",
+                    value: "Including members':\n\nCorrespondence address\nAppointment date\nCountry of residence\nDate of birth (month and year)\n"
+                },
+                {
+                    key: "Administrators' details",
+                    value: "No"
+                },
+                {
+                    key: "Delivery method",
+                    value: "Standard delivery (aim to dispatch within 10 working days)"
+                },
+                {
+                    key: "Email copy required",
+                    value: "Email only available for express delivery method"
+                },
+                {
+                    key: "Fee",
+                    value: "£15"
+                }
+            ],
+            backLinkUrl: "javascript:history.back()"
+        },
+        template: "orderItemSummary/order_item_summary_certificate.njk"
+    }],
+    data: {
+        title: "Summary of item CRT-123456-123456 in order ORD-123456-123456"
+    },
+    template: "page"
+};
+
+export const mockLiquidatedLLPCertificateItemView: ViewModel = {
+    controls: [{
+        controls: [],
+        data: {
+            orderId: ORDER_ID,
+            itemId: CERTIFICATE_ID,
+            itemDetails: [
+                {
+                    key: "Company name",
+                    value: "Company Name"
+                },
+                {
+                    key: "Company number",
+                    value: "00000000"
+                },
+                {
+                    key: "Certificate type",
+                    value: "Incorporation with all company name changes"
+                },
+                {
+                    key: "Registered office address",
+                    value: "Current address and the one previous"
+                },
+                {
+                    key: "The names of all current designated members",
+                    value: "No"
+                },
+                {
+                    key: "The names of all current members",
+                    value: "No"
+                },
+                {
+                    key: "Liquidators' details",
+                    value: "Yes"
+                },
+                {
+                    key: "Delivery method",
+                    value: "Standard delivery (aim to dispatch within 10 working days)"
+                },
+                {
+                    key: "Email copy required",
+                    value: "Email only available for express delivery method"
+                },
+                {
+                    key: "Fee",
+                    value: "£15"
+                }
+            ],
+            backLinkUrl: "javascript:history.back()"
+        },
+        template: "orderItemSummary/order_item_summary_certificate.njk"
+    }],
+    data: {
+        title: "Summary of item CRT-123456-123456 in order ORD-123456-123456"
+    },
+    template: "page"
+};
+
+export const mockActiveLPCertificateItemView = {
+    controls: [{
+        controls: [],
+        data: {
+            orderId: ORDER_ID,
+            itemId: CERTIFICATE_ID,
+            itemDetails: [
+                {
+                    key: "Company name",
+                    value: "Company Name"
+                },
+                {
+                    key: "Company number",
+                    value: "00000000"
+                },
+                {
+                    key: "Certificate type",
+                    value: "Incorporation with all company name changes"
+                },
+                {
+                    key: "Statement of good standing",
+                    value: "Yes"
+                },
+                {
+                    key: "Principal place of business",
+                    value: "Current address and the one previous"
+                },
+                {
+                    key: "The names of all current general partners",
+                    value: "Yes"
+                },
+                {
+                    key: "The names of all current limited partners",
+                    value: "Yes"
+                },
+                {
+                    key: "General nature of business",
+                    value: "Yes"
                 },
                 {
                     key: "Delivery method",

--- a/test/__mocks__/mocks.ts
+++ b/test/__mocks__/mocks.ts
@@ -1,4 +1,10 @@
 import { Item } from "@companieshouse/api-sdk-node/dist/services/order/order/types";
+import {CertificateItemSummaryView} from "../../src/orderitemsummary/CertificateItemSummaryView";
+import {ItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/certificates";
+import {ViewModel} from "../../dist/core/ViewModel";
+
+export const ORDER_ID = "ORD-123456-123456";
+export const CERTIFICATE_ID = "CRT-123456-123456";
 
 export const mockMissingImageDeliveryItem: Item = {
     id: "MID-123456-123456",
@@ -43,7 +49,7 @@ export const mockMissingImageDeliveryItem: Item = {
     postalDelivery: false
 };
 
-export const mockMidOrderItemView = {
+export const mockMidOrderItemView: ViewModel = {
     controls: [{
         controls: [],
         data: {
@@ -61,6 +67,325 @@ export const mockMidOrderItemView = {
     }],
     data: {
         title: "Summary of item MID-123456-123456 in order ORD-123456-123456"
+    },
+    template: "page"
+};
+
+export const mockCertificateItem: Item = {
+    id: CERTIFICATE_ID,
+    companyName: "Company Name",
+    companyNumber: "00000000",
+    description: "certificate for company 00000000",
+    descriptionIdentifier: "certificate",
+    descriptionValues: {
+        certificate: "certificate for company 00000000",
+        companyNumber: "00000000"
+    },
+    itemCosts: [{
+        discountApplied: "0",
+        itemCost: "15",
+        calculatedCost: "15",
+        productType: "certificate"
+    }],
+    itemOptions: {
+        certificateType: "incorporation-with-all-name-changes",
+        deliveryMethod: "postal",
+        deliveryTimescale: "standard",
+        directorDetails: {
+            includeBasicInformation: true
+        },
+        forename: "forename",
+        includeGoodStandingInformation: true,
+        registeredOfficeAddressDetails: {
+            includeAddressRecordsType: "current-and-previous"
+        },
+        secretaryDetails: {
+            includeBasicInformation: true
+        },
+        surname: "surname",
+        companyType: "ltd"
+    } as ItemOptions,
+    etag: "abcdefg123456",
+    kind: "item#certificate",
+    links: {
+        self: "/orderable/certificates/" + CERTIFICATE_ID
+    },
+    postalDelivery: true,
+    quantity: 1,
+    itemUri: "/orderable/certificates/" + CERTIFICATE_ID,
+    status: "unknown",
+    postageCost: "0",
+    totalItemCost: "15",
+    customerReference: "mycert",
+    satisfiedAt: "2020-05-15T08:41:05.798Z"
+};
+
+export const mockDissolvedCertificateItem: Item = {
+    id: CERTIFICATE_ID,
+    companyName: "Company Name",
+    companyNumber: "00000000",
+    description: "certificate for company 00000000",
+    descriptionIdentifier: "certificate",
+    descriptionValues: {
+        certificate: "certificate for company 00000000",
+        companyNumber: "00000000"
+    },
+    itemCosts: [{
+        discountApplied: "0",
+        itemCost: "15",
+        calculatedCost: "15",
+        productType: "certificate"
+    }],
+    itemOptions: {
+        certificateType: "dissolution",
+        deliveryMethod: "postal",
+        deliveryTimescale: "standard",
+        includeEmailCopy: false,
+        directorDetails: {},
+        forename: "forename",
+        registeredOfficeAddressDetails: {},
+        secretaryDetails: {},
+        surname: "surname"
+    } as ItemOptions,
+    etag: "abcdefg123456",
+    kind: "item#certificate",
+    links: {
+        self: "/orderable/certificates/" + CERTIFICATE_ID
+    },
+    postalDelivery: true,
+    quantity: 1,
+    itemUri: "/orderable/certificates/" + CERTIFICATE_ID,
+    status: "unknown",
+    postageCost: "0",
+    totalItemCost: "15",
+    customerReference: "mycert",
+    satisfiedAt: "2020-05-15T08:41:05.798Z"
+};
+
+export const mockActiveLtdCertificateItemView: ViewModel = {
+    controls: [{
+        controls: [],
+        data: {
+            orderId: ORDER_ID,
+            itemId: CERTIFICATE_ID,
+            itemDetails: [
+                {
+                    key: "Company name",
+                    value: "Company Name"
+                },
+                {
+                    key: "Company number",
+                    value: "00000000"
+                },
+                {
+                    key: "Certificate type",
+                    value: "Incorporation with all company name changes"
+                },
+                {
+                    key: "Statement of good standing",
+                    value: "Yes"
+                },
+                {
+                    key: "Registered office address",
+                    value: "Current address and the one previous"
+                },
+                {
+                    key: "The names of all current company directors",
+                    value: "Yes"
+                },
+                {
+                    key: "The names of all current secretaries",
+                    value: "Yes"
+                },
+                {
+                    key: "Company objects",
+                    value: "No"
+                },
+                {
+                    key: "Delivery method",
+                    value: "Standard delivery (aim to dispatch within 10 working days)"
+                },
+                {
+                    key: "Email copy required",
+                    value: "Email only available for express delivery method"
+                },
+                {
+                    key: "Fee",
+                    value: "£15"
+                }
+            ],
+            backLinkUrl: "javascript:history.back()"
+        },
+        template: "orderItemSummary/order_item_summary_certificate.njk"
+    }],
+    data: {
+        title: "Summary of item CRT-123456-123456 in order ORD-123456-123456"
+    },
+    template: "page"
+};
+
+export const mockAdministratedLtdCertificateItemView: ViewModel = {
+    controls: [{
+        controls: [],
+        data: {
+            orderId: ORDER_ID,
+            itemId: CERTIFICATE_ID,
+                itemDetails: [
+                    {
+                        key: "Company name",
+                        value: "Company Name"
+                    },
+                    {
+                        key: "Company number",
+                        value: "00000000"
+                    },
+                    {
+                        key: "Certificate type",
+                        value: "Incorporation with all company name changes"
+                    },
+                    {
+                        key: "Registered office address",
+                        value: "Current address and the one previous"
+                    },
+                    {
+                        key: "The names of all current company directors",
+                        value:  "Yes"
+                    },
+                    {
+                        key: "The names of all current secretaries",
+                        value: "Yes"
+                    },
+                    {
+                        key: "Company objects",
+                        value: "No"
+                    },
+                    {
+                        key: "Administrators' details",
+                        value: "No"
+                    },
+                    {
+                        key: "Delivery method",
+                        value: "Standard delivery (aim to dispatch within 10 working days)"
+                    },
+                    {
+                        key: "Email copy required",
+                        value: "Email only available for express delivery method"
+                    },
+                    {
+                        key: "Fee",
+                        value: "£15"
+                    }
+                ],
+            backLinkUrl: "javascript:history.back()"
+        },
+        template: "orderItemSummary/order_item_summary_certificate.njk"
+    }],
+    data: {
+        title: "Summary of item CRT-123456-123456 in order ORD-123456-123456"
+    },
+    template: "page"
+};
+
+export const mockLiquidatedLtdCertificateItemView: ViewModel = {
+    controls: [{
+        controls: [],
+        data: {
+            orderId: ORDER_ID,
+            itemId: CERTIFICATE_ID,
+            itemDetails: [
+                {
+                    key: "Company name",
+                    value: "Company Name"
+                },
+                {
+                    key: "Company number",
+                    value: "00000000"
+                },
+                {
+                    key: "Certificate type",
+                    value: "Incorporation with all company name changes"
+                },
+                {
+                    key: "Registered office address",
+                    value: "Current address and the one previous"
+                },
+                {
+                    key: "The names of all current company directors",
+                    value:  "Yes"
+                },
+                {
+                    key: "The names of all current secretaries",
+                    value: "Yes"
+                },
+                {
+                    key: "Company objects",
+                    value: "No"
+                },
+                {
+                    key: "Liquidators' details",
+                    value: "Yes"
+                },
+                {
+                    key: "Delivery method",
+                    value: "Standard delivery (aim to dispatch within 10 working days)"
+                },
+                {
+                    key: "Email copy required",
+                    value: "Email only available for express delivery method"
+                },
+                {
+                    key: "Fee",
+                    value: "£15"
+                }
+            ],
+            backLinkUrl: "javascript:history.back()"
+        },
+        template: "orderItemSummary/order_item_summary_certificate.njk"
+    }],
+    data: {
+        title: "Summary of item CRT-123456-123456 in order ORD-123456-123456"
+    },
+    template: "page"
+};
+
+export const mockDissolvedLtdCertificateItemView: ViewModel = {
+    controls: [{
+        controls: [],
+        data: {
+            orderId: ORDER_ID,
+            itemId: CERTIFICATE_ID,
+            itemDetails:  [
+                {
+                    key: "Company name",
+                    value: "Company Name"
+                },
+                {
+                    key: "Company number",
+                    value: "00000000"
+                },
+                {
+                    key: "Certificate type",
+                    value: "Dissolution with all company name changes"
+                },
+                {
+                    key: "Delivery method",
+                    value: "Standard delivery (aim to dispatch within 10 working days)"
+                },
+                {
+                    key: "Email copy required",
+                    value: "Email only available for express delivery method"
+                },
+                {
+                    key: "Fee",
+                    value: "£15"
+                }
+            ],
+            backLinkUrl: "javascript:history.back()"
+        },
+        template: "orderItemSummary/order_item_summary_certificate.njk"
+    }],
+    data: {
+        title: "Summary of item CRT-123456-123456 in order ORD-123456-123456"
     },
     template: "page"
 };

--- a/test/orderitemsummary/LLPCertificateMapper.unit.test.ts
+++ b/test/orderitemsummary/LLPCertificateMapper.unit.test.ts
@@ -1,0 +1,135 @@
+import {
+    mockActiveLLPCertificateItemView,
+    mockAdministratedLLPCertificateItemView,
+    mockCertificateItem,
+    mockDissolvedCertificateItem, mockDissolvedCertificateItemView,
+    mockLiquidatedLLPCertificateItemView,
+    ORDER_ID
+} from "../__mocks__/mocks";
+import { LLPCertificateMapper } from "../../src/orderitemsummary/LLPCertificateMapper";
+
+describe("LLPCertificateMapper", () => {
+    describe("map", () => {
+        it("Maps a certificate item for an active LLP to a view model", () => {
+            // given
+            const mapper = new LLPCertificateMapper({
+                orderId: ORDER_ID,
+                item: {
+                    ...mockCertificateItem,
+                    itemOptions: {
+                        ...mockCertificateItem.itemOptions,
+                        companyStatus: "active",
+                        companyType: "llp",
+                        designatedMemberDetails: {
+                            includeBasicInformation: true,
+                            includeAddress: false,
+                            includeAppointmentDate: false,
+                            includeCountryOfResidence: false
+                        },
+                        memberDetails: {
+                            includeBasicInformation: true,
+                            includeAddress: false,
+                            includeAppointmentDate: false,
+                            includeCountryOfResidence: false
+                        }
+                    }
+                }
+            });
+
+            // when
+            mapper.map();
+            const actual = mapper.getMappedOrder();
+
+            // then
+            expect(actual).toEqual(mockActiveLLPCertificateItemView);
+        });
+
+        it("Maps a certificate item for an administrated LLP to a view model", () => {
+            // given
+            const mapper = new LLPCertificateMapper({
+                orderId: ORDER_ID,
+                item: {
+                    ...mockCertificateItem,
+                    itemOptions: {
+                        ...mockCertificateItem.itemOptions,
+                        companyStatus: "administration",
+                        companyType: "llp",
+                        designatedMemberDetails: {
+                            includeBasicInformation: true,
+                            includeAddress: true,
+                            includeAppointmentDate: true,
+                            includeCountryOfResidence: true,
+                            includeDobType: "partial"
+                        },
+                        memberDetails: {
+                            includeBasicInformation: true,
+                            includeAddress: true,
+                            includeAppointmentDate: true,
+                            includeCountryOfResidence: true,
+                            includeDobType: "partial"
+                        },
+                        administratorsDetails: {
+                        }
+                    }
+                }
+            });
+
+            // when
+            mapper.map();
+            const actual = mapper.getMappedOrder();
+
+            // then
+            expect(actual).toEqual(mockAdministratedLLPCertificateItemView);
+        });
+
+        it("Maps a certificate item for a liquidated LLP to a view model", () => {
+            // given
+            const mapper = new LLPCertificateMapper({
+                orderId: ORDER_ID,
+                item: {
+                    ...mockCertificateItem,
+                    itemOptions: {
+                        ...mockCertificateItem.itemOptions,
+                        companyStatus: "liquidation",
+                        companyType: "llp",
+                        designatedMemberDetails: {
+                        },
+                        memberDetails: {
+                        },
+                        liquidatorsDetails: {
+                            includeBasicInformation: true
+                        }
+                    }
+                }
+            });
+
+            // when
+            mapper.map();
+            const actual = mapper.getMappedOrder();
+
+            // then
+            expect(actual).toEqual(mockLiquidatedLLPCertificateItemView);
+        });
+
+        it("Maps a certificate item for a dissolved LLP to a view model", () => {
+            // given
+            const mapper = new LLPCertificateMapper({
+                orderId: ORDER_ID,
+                item: {
+                    ...mockDissolvedCertificateItem,
+                    itemOptions: {
+                        ...mockDissolvedCertificateItem.itemOptions,
+                        companyType: "llp"
+                    }
+                }
+            });
+
+            // when
+            mapper.map();
+            const actual = mapper.getMappedOrder();
+
+            // then
+            expect(actual).toEqual(mockDissolvedCertificateItemView);
+        });
+    });
+});

--- a/test/orderitemsummary/LPCertificateMapper.unit.test.ts
+++ b/test/orderitemsummary/LPCertificateMapper.unit.test.ts
@@ -1,0 +1,37 @@
+import { LPCertificateMapper } from "../../src/orderitemsummary/LPCertificateMapper";
+import { mockActiveLPCertificateItemView, mockCertificateItem, ORDER_ID } from "../__mocks__/mocks";
+
+describe("LPCertificateMapper", () => {
+    describe("map", () => {
+       it("Maps an active limited partnership", () => {
+           // given
+           const mapper = new LPCertificateMapper({
+               orderId: ORDER_ID,
+               item: {
+                   ...mockCertificateItem,
+                   itemOptions: {
+                       ...mockCertificateItem.itemOptions,
+                       companyType: "limited-partnership",
+                       principalPlaceOfBusinessDetails: {
+                           includeAddressRecordsType: "current-and-previous"
+                       },
+                       limitedPartnerDetails: {
+                           includeBasicInformation: true
+                       },
+                       generalPartnerDetails: {
+                           includeBasicInformation: true
+                       },
+                       includeGeneralNatureOfBusinessInformation: true
+                   }
+               }
+           });
+
+           // when
+           mapper.map();
+           const actual = mapper.getMappedOrder();
+
+           // then
+           expect(actual).toEqual(mockActiveLPCertificateItemView);
+       });
+    });
+});

--- a/test/orderitemsummary/OrderItemSummaryFactory.unit.test.ts
+++ b/test/orderitemsummary/OrderItemSummaryFactory.unit.test.ts
@@ -1,10 +1,13 @@
 import { OrderItemMapper } from "../../src/orderitemsummary/OrderItemMapper";
 import { OrderItemSummaryFactory } from "../../src/orderitemsummary/OrderItemSummaryFactory";
 import { Item } from "@companieshouse/api-sdk-node/dist/services/order/order/types";
-import { mockMissingImageDeliveryItem } from "../__mocks__/mocks";
+import { mockCertificateItem, mockMissingImageDeliveryItem } from "../__mocks__/mocks";
 import { MissingImageDeliveryMapper } from "../../src/orderitemsummary/MissingImageDeliveryMapper";
 import { NullOrderItemMapper } from "../../src/orderitemsummary/NullOrderItemMapper";
 import { MapperRequest } from "../../src/mappers/MapperRequest";
+import {OtherCompanyTypesCertificateMapper} from "../../src/orderitemsummary/OtherCompanyTypesCertificateMapper";
+import {LLPCertificateMapper} from "../../src/orderitemsummary/LLPCertificateMapper";
+import {LPCertificateMapper} from "../../src/orderitemsummary/LPCertificateMapper";
 
 describe("OrderItemSummaryFactory", () => {
     describe("getMapper", () => {
@@ -15,6 +18,33 @@ describe("OrderItemSummaryFactory", () => {
             const mapper: OrderItemMapper = factory.getMapper(new MapperRequest("ORD-123123-123123", mockMissingImageDeliveryItem));
             // then
             expect(mapper).toBeInstanceOf(MissingImageDeliveryMapper);
+        });
+
+        it("Returns a certificate mapper for other company types", async () => {
+            // given
+            const factory = new OrderItemSummaryFactory();
+            // when
+            const mapper: OrderItemMapper = factory.getMapper(new MapperRequest("ORD-123123-123123", mockCertificateItem));
+            // then
+            expect(mapper).toBeInstanceOf(OtherCompanyTypesCertificateMapper);
+        });
+
+        it("Returns an LLP certificate mapper for certificate item kind for LLP company", async () => {
+            // given
+            const factory = new OrderItemSummaryFactory();
+            // when
+            const mapper: OrderItemMapper = factory.getMapper(new MapperRequest("ORD-123123-123123", {...mockCertificateItem, itemOptions: {...mockCertificateItem.itemOptions, companyType: "llp"}}));
+            // then
+            expect(mapper).toBeInstanceOf(LLPCertificateMapper);
+        });
+
+        it("Returns a limited partnership certificate mapper for certificate item kind for limited partnership company", async () => {
+            // given
+            const factory = new OrderItemSummaryFactory();
+            // when
+            const mapper: OrderItemMapper = factory.getMapper(new MapperRequest("ORD-123123-123123", {...mockCertificateItem, itemOptions: {...mockCertificateItem.itemOptions, companyType: "limited-partnership"}}));
+            // then
+            expect(mapper).toBeInstanceOf(LPCertificateMapper);
         });
 
         it("Returns a null item mapper for unknown item kind", async () => {

--- a/test/orderitemsummary/OtherCompanyTypesCertificateMapper.unit.test.ts
+++ b/test/orderitemsummary/OtherCompanyTypesCertificateMapper.unit.test.ts
@@ -4,7 +4,7 @@ import {
     mockAdministratedLtdCertificateItemView,
     mockCertificateItem,
     mockDissolvedCertificateItem,
-    mockDissolvedLtdCertificateItemView,
+    mockDissolvedCertificateItemView,
     mockLiquidatedLtdCertificateItemView,
     ORDER_ID
 } from "../__mocks__/mocks";
@@ -91,7 +91,7 @@ describe("OtherCompanyTypesCertificateMapper", () => {
             const actual = mapper.getMappedOrder();
 
             // then
-            expect(actual).toEqual(mockDissolvedLtdCertificateItemView);
+            expect(actual).toEqual(mockDissolvedCertificateItemView);
         });
     });
 });

--- a/test/orderitemsummary/OtherCompanyTypesCertificateMapper.unit.test.ts
+++ b/test/orderitemsummary/OtherCompanyTypesCertificateMapper.unit.test.ts
@@ -1,0 +1,97 @@
+import { OtherCompanyTypesCertificateMapper } from "../../src/orderitemsummary/OtherCompanyTypesCertificateMapper";
+import {
+    mockActiveLtdCertificateItemView,
+    mockAdministratedLtdCertificateItemView,
+    mockCertificateItem,
+    mockDissolvedCertificateItem,
+    mockDissolvedLtdCertificateItemView,
+    mockLiquidatedLtdCertificateItemView,
+    ORDER_ID
+} from "../__mocks__/mocks";
+
+describe("OtherCompanyTypesCertificateMapper", () => {
+    describe("map", () => {
+        it("Maps a certificate item for an active limited company to a view model", () => {
+            // given
+            const mapper = new OtherCompanyTypesCertificateMapper({
+                orderId: ORDER_ID,
+                item: {
+                    ...mockCertificateItem,
+                    itemOptions: {
+                        ...mockCertificateItem.itemOptions,
+                        companyStatus: "active"
+                    }
+                }
+            });
+
+            // when
+            mapper.map();
+            const actual = mapper.getMappedOrder();
+
+            // then
+            expect(actual).toEqual(mockActiveLtdCertificateItemView);
+        });
+
+        it("Maps a certificate item for an administrated limited company to a view model", () => {
+            // given
+            const mapper = new OtherCompanyTypesCertificateMapper({
+                orderId: ORDER_ID,
+                item: {
+                    ...mockCertificateItem,
+                    itemOptions: {
+                        ...mockCertificateItem.itemOptions,
+                        companyStatus: "administration",
+                        administratorsDetails: {
+                        }
+                    }
+                }
+            });
+
+            // when
+            mapper.map();
+            const actual = mapper.getMappedOrder();
+
+            // then
+            expect(actual).toEqual(mockAdministratedLtdCertificateItemView);
+        });
+
+        it("Maps a certificate item for a liquidated limited company to a view model", () => {
+            // given
+            const mapper = new OtherCompanyTypesCertificateMapper({
+                orderId: ORDER_ID,
+                item: {
+                    ...mockCertificateItem,
+                    itemOptions: {
+                        ...mockCertificateItem.itemOptions,
+                        companyStatus: "liquidation",
+                        liquidatorsDetails: {
+                            includeBasicInformation: true
+                        }
+                    }
+                }
+            });
+
+            // when
+            mapper.map();
+            const actual = mapper.getMappedOrder();
+
+            // then
+            expect(actual).toEqual(mockLiquidatedLtdCertificateItemView);
+        });
+
+        it("Maps a certificate item for a dissolved limited company to a view model", () => {
+            // given
+            const mapper = new OtherCompanyTypesCertificateMapper({
+                orderId: ORDER_ID,
+                item: mockDissolvedCertificateItem
+            });
+
+            // when
+            mapper.map();
+            const actual = mapper.getMappedOrder();
+
+            // then
+            expect(actual).toEqual(mockDissolvedLtdCertificateItemView);
+        });
+    });
+});


### PR DESCRIPTION
* Implement certificate item summary mappers for LLP, LP and other company types.
* Mappers construct a `ViewModel` object representing page & controls to be rendered.

Resolves:
[GCI-2315](https://companieshouse.atlassian.net/browse/GCI-2315)