### PR TITLE
Use getCheckoutItem endpoint

### DIFF
--- a/features/support/order_item_summary/OrderItemSummaryPage.ts
+++ b/features/support/order_item_summary/OrderItemSummaryPage.ts
@@ -84,17 +84,17 @@ export class NoPage extends AbstractOrderItemSummaryPageState {
     }
 
     async anticipateSuccessfulResponse(json: any): Promise<void> {
-        this.stubApiClient.willReturnSuccessfulOrderItemResponse(json);
+        this.stubApiClient.willReturnSuccessfulCheckoutItemResponse(json);
         this.stateMachine.currentState = this.stateMachine.anticipateOrderItemSummary;
     }
 
     async anticipateClientError(json: any): Promise<void> {
-        this.stubApiClient.willReturnErrorOrderItemResponse(404, json);
+        this.stubApiClient.willReturnErrorCheckoutItemResponse(404, json);
         this.stateMachine.currentState = this.stateMachine.anticipateItemNotFound;
     }
 
     async anticipateServerError(json: any): Promise<void> {
-        this.stubApiClient.willReturnErrorOrderItemResponse(500, json);
+        this.stubApiClient.willReturnErrorCheckoutItemResponse(500, json);
         this.stateMachine.currentState = this.stateMachine.anticipateServiceUnavailable;
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -448,9 +448,9 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
     "@companieshouse/api-sdk-node": {
-      "version": "2.0.31",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.31.tgz",
-      "integrity": "sha512-+pWDlQuL95xHYvPCDp1VKVtqrMvgsLkJiLlKoscK2FXUd+6bPwLk0BNyhdcAhBiJGEVfovyuDzyowRxjNMm9EA==",
+      "version": "2.0.33",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.33.tgz",
+      "integrity": "sha512-3HytTn2R/zy11hCr85+kg3mHDFS8kKDSgFMmC9kSfVTl2F5P6FFvh777ARcvbuXs63kljUdOznAVQSXOWd0xOQ==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",
@@ -5384,7 +5384,7 @@
     "http-errors": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sonarqube": "sonar-scanner"
   },
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.31",
+    "@companieshouse/api-sdk-node": "^2.0.33",
     "@companieshouse/node-session-handler": "~4.1.6",
     "@companieshouse/structured-logging-node": "^1.0.4",
     "@types/nunjucks": "^3.2.1",

--- a/src/client/StubApiClientFactory.ts
+++ b/src/client/StubApiClientFactory.ts
@@ -11,6 +11,7 @@ import {Checkout} from "@companieshouse/api-sdk-node/dist/services/order/checkou
 import {ItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/order";
 import {Item} from "@companieshouse/api-sdk-node/dist/services/order/order/types";
 import {OrderItemErrorResponse} from "@companieshouse/api-sdk-node/dist/services/order/order-item/service";
+import {CheckoutItemErrorResponse} from "../../../api-sdk-node/dist/services/order/checkout-item/service";
 
 @Service("stub.client")
 export class StubApiClientFactory implements ApiClientFactory {
@@ -24,7 +25,7 @@ export class StubApiClientFactory implements ApiClientFactory {
     };
     private searchResponse: ApiResult<ApiResponse<SearchResponse>> | undefined;
     private checkoutResponse: ApiResult<ApiResponse<Checkout>> | undefined;
-    private orderItemResponse: Result<Item, OrderItemErrorResponse> | undefined;
+    private checkoutItemResponse: Result<Item, OrderItemErrorResponse> | undefined;
     private readonly defaultSearchResponse: ApiResult<ApiResponse<SearchResponse>> = new Success<ApiResponse<SearchResponse>, ApiErrorResponse>({
         httpStatusCode: 200,
         resource: {
@@ -136,7 +137,7 @@ export class StubApiClientFactory implements ApiClientFactory {
         }
     });
 
-    private defaultOrderItemResponse: ApiResult<Item> = new Success<Item, OrderItemErrorResponse>({
+    private defaultCheckoutItemResponse: Result<Item, CheckoutItemErrorResponse> = new Success<Item, OrderItemErrorResponse>({
         id: "CRT-123456-123456",
         companyName: "TEST COMPANY LIMITED",
         companyNumber: "00000000",
@@ -213,12 +214,12 @@ export class StubApiClientFactory implements ApiClientFactory {
         });
     }
 
-    willReturnSuccessfulOrderItemResponse(body: any): void {
-        this.orderItemResponse = new Success<Item, OrderItemErrorResponse>(Mapping.camelCaseKeys(body, StubApiClientFactory.EXCLUDED_FIELDS));
+    willReturnSuccessfulCheckoutItemResponse(body: any): void {
+        this.checkoutItemResponse = new Success<Item, CheckoutItemErrorResponse>(Mapping.camelCaseKeys(body, StubApiClientFactory.EXCLUDED_FIELDS));
     }
 
-    willReturnErrorOrderItemResponse(statusCode: number, body: any): void {
-        this.orderItemResponse = new Failure<Item, OrderItemErrorResponse>({
+    willReturnErrorCheckoutItemResponse(statusCode: number, body: any): void {
+        this.checkoutItemResponse = new Failure<Item, CheckoutItemErrorResponse>({
             httpStatusCode: statusCode,
             error: Mapping.camelCaseKeys(body)
         });
@@ -237,9 +238,9 @@ export class StubApiClientFactory implements ApiClientFactory {
                     return self.searchResponse || self.defaultSearchResponse;
                 }
             },
-            orderItem: {
-                async getOrderItem(orderId: string, itemId: string): Promise<ApiResult<Item>> {
-                    return self.orderItemResponse || self.defaultOrderItemResponse;
+            checkoutItem: {
+                async getCheckoutItem(orderId: string, itemId: string): Promise<Result<Item, CheckoutItemErrorResponse>> {
+                    return self.checkoutItemResponse || self.defaultCheckoutItemResponse;
                 }
             }
         } as ApiClient;

--- a/src/orderitemsummary/OrderItemSummaryService.ts
+++ b/src/orderitemsummary/OrderItemSummaryService.ts
@@ -23,7 +23,7 @@ export class OrderItemSummaryService {
 
     async getOrderItem (request: OrderItemRequest): Promise<OrderItemView> {
         const apiClient: ApiClient = this.apiClientFactory.newApiClient(request.apiToken);
-        const response: Result<Item, OrderItemErrorResponse> = await apiClient.orderItem.getOrderItem(request.orderId, request.itemId);
+        const response: Result<Item, OrderItemErrorResponse> = await apiClient.checkoutItem.getCheckoutItem(request.orderId, request.itemId);
 
         if (response.isSuccess()) {
             const mapper = this.factory.getMapper(new MapperRequest(request.orderId, response.value));

--- a/test/orderitemsummary/OrderItemSummaryService.test.ts
+++ b/test/orderitemsummary/OrderItemSummaryService.test.ts
@@ -18,14 +18,14 @@ describe("OrderItemSummaryService", () => {
             // given
             const response = new Success<Item, OrderItemErrorResponse>(mockMissingImageDeliveryItem);
 
-            const orderItem: any = {};
-            orderItem.getOrderItem = jest.fn(() => {
+            const checkoutItem: any = {};
+            checkoutItem.getCheckoutItem = jest.fn(() => {
                 return response;
             });
             const apiClientFactory: any = {};
             apiClientFactory.newApiClient = jest.fn(() => {
                 return {
-                    orderItem: orderItem
+                    checkoutItem: checkoutItem
                 };
             });
 
@@ -56,7 +56,7 @@ describe("OrderItemSummaryService", () => {
                 viewModel: mappedResults
             });
             expect(apiClientFactory.newApiClient).toHaveBeenCalled();
-            expect(orderItem.getOrderItem).toHaveBeenCalledWith("ORD-123456-123456", "MID-123456-123456");
+            expect(checkoutItem.getCheckoutItem).toHaveBeenCalledWith("ORD-123456-123456", "MID-123456-123456");
             expect(mapper.map).toHaveBeenCalled();
             expect(mapper.getMappedOrder).toHaveBeenCalled();
             expect(factory.getMapper).toHaveBeenCalledWith(new MapperRequest( "ORD-123456-123456", mockMissingImageDeliveryItem));
@@ -69,8 +69,8 @@ describe("OrderItemSummaryService", () => {
                 error: "Not found"
             });
 
-            const orderItem: any = {};
-            orderItem.getOrderItem = jest.fn(() => {
+            const checkoutItem: any = {};
+            checkoutItem.getCheckoutItem = jest.fn(() => {
                 return response;
             });
 
@@ -84,7 +84,7 @@ describe("OrderItemSummaryService", () => {
             const apiClientFactory: any = {};
             apiClientFactory.newApiClient = jest.fn(() => {
                 return {
-                    orderItem: orderItem
+                    checkoutItem: checkoutItem
                 };
             });
 
@@ -102,7 +102,7 @@ describe("OrderItemSummaryService", () => {
             // then
             expect(result).toStrictEqual(mappedResults);
             expect(apiClientFactory.newApiClient).toHaveBeenCalled();
-            expect(orderItem.getOrderItem).toHaveBeenCalledWith("ORD-123456-123456", "MID-123456-123456");
+            expect(checkoutItem.getCheckoutItem).toHaveBeenCalledWith("ORD-123456-123456", "MID-123456-123456");
             expect(mapper.map).toHaveBeenCalledTimes(0);
             expect(mapper.getMappedOrder).toHaveBeenCalledTimes(0);
             expect(factory.getMapper).toHaveBeenCalledTimes(0);
@@ -114,14 +114,14 @@ describe("OrderItemSummaryService", () => {
                 httpStatusCode: 500
             });
 
-            const orderItem: any = {};
-            orderItem.getOrderItem = jest.fn(() => {
+            const checkoutItem: any = {};
+            checkoutItem.getCheckoutItem = jest.fn(() => {
                 return response;
             });
             const apiClientFactory: any = {};
             apiClientFactory.newApiClient = jest.fn(() => {
                 return {
-                    orderItem: orderItem
+                    checkoutItem: checkoutItem
                 };
             });
 
@@ -139,7 +139,7 @@ describe("OrderItemSummaryService", () => {
             // then
             expect(result).toStrictEqual(mappedResults);
             expect(apiClientFactory.newApiClient).toHaveBeenCalled();
-            expect(orderItem.getOrderItem).toHaveBeenCalledWith("ORD-123456-123456", "MID-123456-123456");
+            expect(checkoutItem.getCheckoutItem).toHaveBeenCalledWith("ORD-123456-123456", "MID-123456-123456");
         });
     });
 });


### PR DESCRIPTION
* Call to getOrderItem endpoint in OrderItemSummaryService replaced with
  getCheckoutItem call to fetch checkout item resource.
* Allows items for unpaid orders to be viewed.

Related: https://github.com/companieshouse/api-sdk-node/pull/462