### PR TITLE
Updating healthcheck path and matcher

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -9,8 +9,8 @@ locals {
   kms_alias                  = "alias/${var.aws_profile}/environment-services-kms"
   lb_listener_rule_priority  = 9
   lb_listener_paths          = ["/orders-admin/*"]
-  healthcheck_path           = "/orders-admin/search"
-  healthcheck_matcher        = "302"
+  healthcheck_path           = "/orders-admin/stylesheets/app.css"
+  healthcheck_matcher        = "200"
   vpc_name                   = local.stack_secrets["vpc_name"]
   s3_config_bucket           = data.vault_generic_secret.shared_s3.data["config_bucket_name"]
   app_environment_filename   = "admin.orders.web.ch.gov.uk.env"

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -1,26 +1,26 @@
 # Define all hardcoded local variable and local variables looked up from data resources
 locals {
-  stack_name                = "order-service" # this must match the stack name the service deploys into
-  name_prefix               = "${local.stack_name}-${var.environment}"
-  global_prefix             = "global-${var.environment}"
-  service_name              = "admin-orders-web"
-  container_port            = "3000" # default node port required here until prod docker container is built allowing port change via env var
-  docker_repo               = "admin.orders.web.ch.gov.uk"
-  kms_alias                 = "alias/${var.aws_profile}/environment-services-kms"
-  lb_listener_rule_priority = 9
-  lb_listener_paths         = ["/orders-admin/*"]
-  healthcheck_path          = "/orders-admin" #healthcheck path for confirmation statement web
-  healthcheck_matcher       = "200"       # no explicit healthcheck in this service yet, change this when added!
-  vpc_name                    = local.stack_secrets["vpc_name"]
-  s3_config_bucket            = data.vault_generic_secret.shared_s3.data["config_bucket_name"]
-  app_environment_filename    = "admin.orders.web.ch.gov.uk.env"
-  use_set_environment_files   = var.use_set_environment_files
-  application_subnet_ids      = data.aws_subnets.application.ids
+  stack_name                 = "order-service" # this must match the stack name the service deploys into
+  name_prefix                = "${local.stack_name}-${var.environment}"
+  global_prefix              = "global-${var.environment}"
+  service_name               = "admin-orders-web"
+  container_port             = "3000" # default node port required here until prod docker container is built allowing port change via env var
+  docker_repo                = "admin.orders.web.ch.gov.uk"
+  kms_alias                  = "alias/${var.aws_profile}/environment-services-kms"
+  lb_listener_rule_priority  = 9
+  lb_listener_paths          = ["/orders-admin/*"]
+  healthcheck_path           = "/orders-admin/search"
+  healthcheck_matcher        = "302"
+  vpc_name                   = local.stack_secrets["vpc_name"]
+  s3_config_bucket           = data.vault_generic_secret.shared_s3.data["config_bucket_name"]
+  app_environment_filename   = "admin.orders.web.ch.gov.uk.env"
+  use_set_environment_files  = var.use_set_environment_files
+  application_subnet_ids     = data.aws_subnets.application.ids
   stack_secrets              = jsondecode(data.vault_generic_secret.stack_secrets.data_json)
   application_subnet_pattern = local.stack_secrets["application_subnet_pattern"]
 
-  service_secrets            = jsondecode(data.vault_generic_secret.service_secrets.data_json)
-  
+  service_secrets = jsondecode(data.vault_generic_secret.service_secrets.data_json)
+
   # create a map of secret name => secret arn to pass into ecs service module
   # using the trimprefix function to remove the prefixed path from the secret name
   secrets_arn_map = {
@@ -33,7 +33,7 @@ locals {
     trimprefix(sec.name, "/${local.global_prefix}/") => sec.arn
   }
 
-  global_secret_list = flatten([for key, value in local.global_secrets_arn_map : 
+  global_secret_list = flatten([for key, value in local.global_secrets_arn_map :
     { "name" = upper(key), "valueFrom" = value }
   ])
 
@@ -44,11 +44,11 @@ locals {
   ]
 
   service_secrets_arn_map = {
-    for sec in module.secrets.secrets:
-      trimprefix(sec.name, "/${local.service_name}-${var.environment}/") => sec.arn
+    for sec in module.secrets.secrets :
+    trimprefix(sec.name, "/${local.service_name}-${var.environment}/") => sec.arn
   }
 
-  service_secret_list = flatten([for key, value in local.service_secrets_arn_map : 
+  service_secret_list = flatten([for key, value in local.service_secrets_arn_map :
     { "name" = upper(key), "valueFrom" = value }
   ])
 
@@ -59,9 +59,9 @@ locals {
   ]
 
   # secrets to go in list
-  task_secrets = concat(local.service_secret_list,local.global_secret_list,[])
+  task_secrets = concat(local.service_secret_list, local.global_secret_list, [])
 
-  task_environment = concat(local.ssm_global_version_map,local.ssm_service_version_map,[
+  task_environment = concat(local.ssm_global_version_map, local.ssm_service_version_map, [
     { "name" : "PORT", "value" : local.container_port },
   ])
-  }
+}


### PR DESCRIPTION
With the current settings, service keeps being terminated by the load balancer, as the proposed endpoint returns 404 instead of 200. The proposal is to set healt-check path to /orders-admin/search, and accept 302 as a valid response; otherwise, an explicit health-check endpoint will need to be created. 

Current version of ecs-service terraform module [does not accept multiple response codes](https://github.com/companieshouse/terraform-modules/blob/5b1fa49b171a279b4e2521cff52d6d98bc88d4c4/aws/ecs/ecs-service/locals.tf#L55-L67). 