### PR TITLE
BI-12454: Update payment enum to include free orders

### DIFF
--- a/src/order_summary/OrderSummaryConverter.ts
+++ b/src/order_summary/OrderSummaryConverter.ts
@@ -11,7 +11,8 @@ const paymentStatusMappings: {[key: string]: string} = {
     "expired": "Expired",
     "in-progress": "In progress",
     "cancelled": "Cancelled",
-    "no-funds": "No funds"
+    "no-funds": "No funds",
+    "free": "Free (Admin Order)"
 };
 
 export class OrderSummaryConverter {

--- a/src/search/SearchResultsMapper.ts
+++ b/src/search/SearchResultsMapper.ts
@@ -22,7 +22,8 @@ const paymentStatusMappings: {[key: string]: string} = {
     "expired": "Expired",
     "in-progress": "In progress",
     "cancelled": "Cancelled",
-    "no-funds": "No funds"
+    "no-funds": "No funds",
+    "free": "Free (Admin Order)"
 };
 
 @Service()


### PR DESCRIPTION
This allows the payment status of a free admin order to be correctly presented.