### PR TITLE
BI-14023 - Add quantity to admin order summary page

### DIFF
--- a/features/order_summary_page.feature
+++ b/features/order_summary_page.feature
@@ -7,12 +7,12 @@ Feature: Order summary page
     Given The checkout contains all known item types with all known delivery timescales
     When I view the order summary
     Then The following items should be displayed:
-      | Item number       | Order type         | Company number | Dispatch method | Fee |
-      | MID-123123-123123 | Missing image      | 12345678       | N/A             | £3  |
-      | CRT-123123-123123 | Certificate        | 12345678       | Standard        | £15 |
-      | CRT-123123-123124 | Certificate        | 12345679       | Express         | £50 |
-      | CCD-123123-123123 | Certified document | 12345678       | Standard        | £15 |
-      | CCD-123123-123124 | Certified document | 12345670       | Express         | £50 |
+      | Item number       | Order type         | Company number | Dispatch method | Quantity| Fee |
+      | MID-123123-123123 | Missing image      | 12345678       | N/A             | 1       |  £3 |
+      | CRT-123123-123123 | Certificate        | 12345678       | Standard        | 1       | £15 |
+      | CRT-123123-123124 | Certificate        | 12345679       | Express         | 1       | £50 |
+      | CCD-123123-123123 | Certified document | 12345678       | Standard        | 1       | £15 |
+      | CCD-123123-123124 | Certified document | 12345670       | Express         | 1       | £50 |
     And Delivery details for the order should be:
       | Delivery address                                                                      |
       | Forename Surname\nAddress line 1\nAddress line 2\nLocality\nRegion\nPostcode\nCountry |
@@ -24,8 +24,8 @@ Feature: Order summary page
     Given The checkout contains no deliverable items
     When I view the order summary
     Then The following items should be displayed:
-      | Item number       | Order type         | Company number | Dispatch method | Fee |
-      | MID-123123-123123 | Missing image      | 12345678       | N/A             | £3  |
+      | Item number       | Order type         | Company number | Dispatch method | Quantity| Fee |
+      | MID-123123-123123 | Missing image      | 12345678       | N/A             | 1       | £3  |
     And Delivery details for the order should not be displayed
     And Payment details for the order should be:
       | Status | Payment reference | Fee  |

--- a/src/order_summary/OrderSummary.ts
+++ b/src/order_summary/OrderSummary.ts
@@ -12,6 +12,7 @@ export class ItemSummary {
     public orderType?: string;
     public companyNumber?: string;
     public deliveryMethod?: string;
+    public quantity?: number;
     public fee?: string;
     public itemLink?: string;
 }

--- a/src/order_summary/OrderSummaryConverter.ts
+++ b/src/order_summary/OrderSummaryConverter.ts
@@ -50,6 +50,7 @@ export class OrderSummaryConverter {
             orderType: itemType,
             companyNumber: request.item.companyNumber,
             deliveryMethod: deliveryMethod,
+            quantity: request.item.quantity,
             fee: `£${request.item.totalItemCost}`,
             itemLink: `/orders-admin/order-summaries/${request.orderId}/items/${request.item.id}`
         });

--- a/src/views/orderSummary/item_details.njk
+++ b/src/views/orderSummary/item_details.njk
@@ -5,5 +5,6 @@
     <td class="govuk-table__cell">{{ control.data.orderType }}</td>
     <td class="govuk-table__cell">{{ control.data.companyNumber }}</td>
     <td class="govuk-table__cell">{{ control.data.deliveryMethod }}</td>
+    <td class="govuk-table__cell">{{ control.data.quantity }}</td>
     <td class="govuk-table__cell">{{ control.data.fee }}</td>
 </tr>

--- a/src/views/orderSummary/order_summary.njk
+++ b/src/views/orderSummary/order_summary.njk
@@ -9,6 +9,7 @@
                 <th scope="col" class="govuk-table__header">Order type</th>
                 <th scope="col" class="govuk-table__header">Company number</th>
                 <th scope="col" class="govuk-table__header">Dispatch method</th>
+                <th scope="col" class="govuk-table__header">Quantity</th>
                 <th scope="col" class="govuk-table__header">Fee</th>
             </tr>
             </thead>

--- a/test/order_summary/OrderSummaryService.unit.test.ts
+++ b/test/order_summary/OrderSummaryService.unit.test.ts
@@ -36,6 +36,7 @@ describe("OrderSummaryService", () => {
                         orderType: "Missing image",
                         companyNumber: "12345678",
                         deliveryMethod: "N/A",
+                        quantity: 1,
                         fee: "£3",
                         itemLink: "/orders-admin/order-summaries/ORD-123123-123123/items/MID-123123-123123"
                     },
@@ -44,6 +45,7 @@ describe("OrderSummaryService", () => {
                         orderType: "Certificate",
                         companyNumber: "12345678",
                         deliveryMethod: "Standard",
+                        quantity: 1,
                         fee: "£15",
                         itemLink: "/orders-admin/order-summaries/ORD-123123-123123/items/CRT-123123-123123"
                     },
@@ -52,6 +54,7 @@ describe("OrderSummaryService", () => {
                         orderType: "Certificate",
                         companyNumber: "12345679",
                         deliveryMethod: "Express",
+                        quantity: 1,
                         fee: "£50",
                         itemLink: "/orders-admin/order-summaries/ORD-123123-123123/items/CRT-123123-123124"
                     },
@@ -60,6 +63,7 @@ describe("OrderSummaryService", () => {
                         orderType: "Certified document",
                         companyNumber: "12345678",
                         deliveryMethod: "Standard",
+                        quantity: 1,
                         fee: "£15",
                         itemLink: "/orders-admin/order-summaries/ORD-123123-123123/items/CCD-123123-123123"
                     },
@@ -68,6 +72,7 @@ describe("OrderSummaryService", () => {
                         orderType: "Certified document",
                         companyNumber: "12345670",
                         deliveryMethod: "Express",
+                        quantity: 1,
                         fee: "£50",
                         itemLink: "/orders-admin/order-summaries/ORD-123123-123123/items/CCD-123123-123124"
                     }
@@ -103,6 +108,7 @@ describe("OrderSummaryService", () => {
                         orderType: "Missing image",
                         companyNumber: "12345678",
                         deliveryMethod: "N/A",
+                        quantity: 1,
                         fee: "£3",
                         itemLink: "/orders-admin/order-summaries/ORD-123123-123123/items/MID-123123-123123"
                     }


### PR DESCRIPTION
Fulfils [BI-14023](https://companieshouse.atlassian.net/browse/BI-14023)
- Update admin order summary page to include quantity column
- update unit and integration tests

new order summary page:
<img width="1009" alt="Screenshot 2024-09-30 at 17 45 22" src="https://github.com/user-attachments/assets/e4b7dca5-a7e7-48a8-a5f2-7712aadf53c1">


[BI-14023]: https://companieshouse.atlassian.net/browse/BI-14023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ